### PR TITLE
Require price selection for ticket services

### DIFF
--- a/app/Exports/DashboardExport.php
+++ b/app/Exports/DashboardExport.php
@@ -49,7 +49,7 @@ class DashboardExport implements WithMultipleSheets, Responsable
                     $payments = WasherPayment::whereDate('payment_date','>=',$this->start)
                         ->whereDate('payment_date','<=',$this->end)->get();
                     foreach($payments as $p){
-                        $rows[] = ['Pago Lavador '.$p->washer->name, $p->payment_date->format('d/m/Y h:i A'), -$p->amount_paid];
+                        $rows[] = ['Pago Estilista '.$p->washer->name, $p->payment_date->format('d/m/Y h:i A'), -$p->amount_paid];
                     }
                     return collect($rows);
                 }
@@ -86,7 +86,7 @@ class DashboardExport implements WithMultipleSheets, Responsable
                 public function headings(): array
                 { return ['Producto','Tipo','Cantidad','Fecha']; }
             },
-            'Lavadores' => new class($this->start,$this->end) implements FromCollection, WithHeadings {
+            'Estilistas' => new class($this->start,$this->end) implements FromCollection, WithHeadings {
                 private $start;private $end;
                 public function __construct($s,$e){$this->start=$s;$this->end=$e;}
                 public function collection(){
@@ -100,7 +100,7 @@ class DashboardExport implements WithMultipleSheets, Responsable
                         ]);
                 }
                 public function headings(): array
-                { return ['Lavador','Fecha','Monto']; }
+                { return ['Estilista','Fecha','Monto']; }
             },
         ];
     }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -182,7 +182,7 @@ class DashboardController extends Controller
         }
         foreach (WasherPayment::whereDate('payment_date', '>=', $start)->whereDate('payment_date', '<=', $end)->get() as $p) {
             $movements[] = [
-                'description' => 'Pago Lavador '.$p->washer->name,
+                'description' => 'Pago Estilista '.$p->washer->name,
                 'date' => $p->payment_date->format('d/m/Y h:i A'),
                 'amount' => -$p->amount_paid,
             ];

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -169,12 +169,21 @@ class TicketController extends Controller
 
     public function create()
     {
-        $services = Service::where('active', true)->with('prices')->get();
+        $services = Service::where('active', true)
+            ->with('prices.vehicleType')
+            ->orderBy('name')
+            ->get();
+
         $servicePrices = [];
         foreach ($services as $service) {
-            foreach ($service->prices as $price) {
-                $servicePrices[$service->id][$price->vehicle_type_id] = $price->price;
-            }
+            $servicePrices[$service->id] = $service->prices->map(function ($price) {
+                return [
+                    'id' => $price->id,
+                    'label' => $price->label ?? optional($price->vehicleType)->name ?? 'General',
+                    'price' => $price->price,
+                    'vehicle_type_id' => $price->vehicle_type_id,
+                ];
+            })->values();
         }
 
         $products = Product::where('stock', '>', 0)->orderBy('name')->get();
@@ -222,7 +231,6 @@ class TicketController extends Controller
 
         return view('tickets.create', [
             'services' => $services,
-            'vehicleTypes' => VehicleType::all(),
             'products' => $products,
             'washers' => Washer::where('active', true)->orderBy('name')->get(),
             'bankAccounts' => BankAccount::all(),
@@ -239,334 +247,7 @@ class TicketController extends Controller
 
     public function store(Request $request)
     {
-        if ($request->has('washes')) {
-            return $this->storeMultiple($request);
-        }
-
-        $pending = $request->input('ticket_action') === 'pending';
-
-        $serviceIds = $request->input('service_ids', []);
-        $hasWash = Service::whereIn('id', $serviceIds)
-            ->where('name', 'like', 'Lavado%')
-            ->exists();
-
-        $rules = [
-            'customer_name' => ['required', 'regex:/^[A-Za-zÁÉÍÓÚáéíóúñÑ\s]+$/', 'max:255'],
-            'vehicle_type_id' => [$hasWash ? 'required' : 'nullable', 'exists:vehicle_types,id'],
-            'customer_phone' => ['nullable','regex:/^[0-9+()\s-]+$/','max:20'],
-            'plate' => [$hasWash ? 'required' : 'nullable', 'alpha_num', 'max:20'],
-            'brand' => [$hasWash ? 'required' : 'nullable', 'regex:/^[A-Za-z0-9\s]+$/', 'max:50'],
-            'model' => [$hasWash ? 'required' : 'nullable', 'regex:/^[A-Za-z0-9\s]+$/', 'max:50'],
-            'color' => [$hasWash ? 'required' : 'nullable', 'regex:/^[A-Za-zÁÉÍÓÚáéíóúñÑ\s]+$/', 'max:50'],
-            'year' => 'nullable|integer|between:1890,' . date('Y'),
-            'washer_id' => 'nullable|exists:washers,id',
-            'service_ids' => 'nullable|array',
-            'service_ids.*' => 'exists:services,id',
-            'product_ids' => 'nullable|array',
-            'product_ids.*' => 'exists:products,id',
-            'quantities' => 'nullable|array',
-            'quantities.*' => 'integer|min:1',
-            'drink_ids' => 'nullable|array',
-            'drink_ids.*' => 'exists:drinks,id',
-            'drink_quantities' => 'nullable|array',
-            'drink_quantities.*' => 'integer|min:1',
-            'ticket_date' => 'required|date|before_or_equal:today',
-        ];
-        if (!$pending) {
-            $rules['payment_method'] = 'required|in:efectivo,tarjeta,transferencia,mixto';
-            $rules['bank_account_id'] = 'required_if:payment_method,transferencia|nullable|exists:bank_accounts,id';
-            $rules['paid_amount'] = 'required|numeric|min:0';
-        }
-
-        $request->validate($rules, [
-            'customer_name.required' => 'El nombre del cliente es obligatorio.',
-            'customer_name.max' => 'El nombre del cliente es demasiado largo.',
-            'vehicle_type_id.required' => 'El tipo de vehículo es obligatorio.',
-            'vehicle_type_id.exists' => 'El tipo de vehículo seleccionado no es válido.',
-            'plate.required' => 'La placa es obligatoria.',
-            'plate.alpha_num' => 'La placa solo puede contener letras y numeros.',
-            'brand.required' => 'La marca es obligatoria.',
-            'brand.regex' => 'La marca solo puede contener letras y numeros.',
-            'model.required' => 'El modelo es obligatorio.',
-            'model.regex' => 'El modelo solo puede contener letras y numeros.',
-            'color.required' => 'El color es obligatorio.',
-            'color.regex' => 'El color solo puede contener letras.',
-            'customer_name.regex' => 'El nombre solo puede contener letras.',
-            'customer_phone.regex' => 'El teléfono solo puede contener números y caracteres + - ()',
-            'year.between' => 'El año debe estar entre 1890 y '.date('Y').'.',
-            'washer_id.exists' => 'El lavador seleccionado no es válido.',
-            'service_ids.*.exists' => 'Alguno de los servicios seleccionados es inválido.',
-            'product_ids.*.exists' => 'Alguno de los productos seleccionados es inválido.',
-            'quantities.*.min' => 'La cantidad debe ser al menos 1.',
-            'drink_ids.*.exists' => 'Alguno de los tragos seleccionados es inválido.',
-            'drink_quantities.*.min' => 'La cantidad debe ser al menos 1.',
-            'payment_method.required' => 'Debe seleccionar un método de pago.',
-            'bank_account_id.required_if' => 'Debe seleccionar una cuenta bancaria.',
-            'paid_amount.required' => 'Debe ingresar el monto pagado.',
-            'paid_amount.numeric' => 'El monto pagado debe ser un número válido.',
-            'paid_amount.min' => 'El monto pagado no puede ser negativo.',
-            'ticket_date.required' => 'La fecha del ticket es obligatoria.',
-            'ticket_date.date' => 'La fecha del ticket no es válida.',
-            'ticket_date.before_or_equal' => 'La fecha del ticket no puede ser futura.'
-        ]);
-
-        DB::beginTransaction();
-
-        try {
-            $ticketDate = Carbon::parse($request->ticket_date)->setTimeFrom(now());
-            $vehicleType = $request->vehicle_type_id ? VehicleType::findOrFail($request->vehicle_type_id) : null;
-            $total = 0;
-            $discountTotal = 0;
-            $details = [];
-            $hasService = false;
-
-            // Servicios
-            foreach ($request->service_ids ?? [] as $serviceId) {
-                $service = Service::where('active', true)->find($serviceId);
-                if (!$service || !$vehicleType) {
-                    continue;
-                }
-                $priceRow = $service->prices()->where('vehicle_type_id', $vehicleType->id)->first();
-                $price = $priceRow ? $priceRow->price : 0;
-
-                $discount = Discount::where('discountable_type', Service::class)
-                    ->where('discountable_id', $serviceId)
-                    ->where('active', true)
-                    ->where(function($q){
-                        $q->whereNull('start_at')->orWhere('start_at','<=', now());
-                    })
-                    ->where(function($q){ $q->whereNull('end_at')->orWhere('end_at','>', now()); })
-                    ->first();
-                if ($discount && $discount->end_at && $discount->end_at->isPast()) {
-                    $discount->update(['active' => false]);
-                    $discount = null;
-                }
-                $discValue = 0;
-                if ($discount) {
-                    $discValue = $discount->amount_type === 'fixed' ? $discount->amount : ($price * $discount->amount / 100);
-                    $price = max(0, $price - $discValue);
-                }
-
-                $details[] = [
-                    'type' => 'service',
-                    'service_id' => $serviceId,
-                    'product_id' => null,
-                    'quantity' => 1,
-                    'unit_price' => $price,
-                    'discount_amount' => $discValue,
-                    'subtotal' => $price,
-                ];
-
-                $total += $price;
-                $discountTotal += $discValue;
-                $hasService = true;
-            }
-
-            // Productos
-            $productMovements = [];
-            if ($request->product_ids) {
-                foreach ($request->product_ids as $index => $productId) {
-                    $product = Product::find($productId);
-                    $qty = $request->quantities[$index];
-                    if (!$product || $product->stock < $qty) {
-                        DB::rollBack();
-                        $message = ['quantities' => ['Stock insuficiente para ' . ($product->name ?? 'producto')]];
-                        if ($request->expectsJson()) {
-                            return response()->json(['errors' => $message], 422);
-                        }
-                        return back()->withErrors($message)->withInput();
-                    }
-                    $price = $product->price;
-                    $discount = Discount::where('discountable_type', Product::class)
-                        ->where('discountable_id', $productId)
-                        ->where('active', true)
-                        ->where(function($q){
-                            $q->whereNull('start_at')->orWhere('start_at','<=', now());
-                        })
-                        ->where(function($q){ $q->whereNull('end_at')->orWhere('end_at','>', now()); })
-                        ->first();
-                    if ($discount && $discount->end_at && $discount->end_at->isPast()) {
-                        $discount->update(['active' => false]);
-                        $discount = null;
-                    }
-                    $discValue = 0;
-                    if ($discount) {
-                        $discValue = $discount->amount_type === 'fixed' ? $discount->amount : ($price * $discount->amount / 100);
-                        $price = max(0, $price - $discValue);
-                    }
-                    $subtotal = $price * $qty;
-
-                    $details[] = [
-                        'type' => 'product',
-                        'service_id' => null,
-                        'product_id' => $productId,
-                        'quantity' => $qty,
-                        'unit_price' => $price,
-                        'discount_amount' => $discValue,
-                        'subtotal' => $subtotal,
-                    ];
-
-                    $total += $subtotal;
-                    $discountTotal += $discValue * $qty;
-
-                    $product->decrement('stock', $qty);
-                    $productMovements[] = [
-                        'product_id' => $productId,
-                        'user_id' => auth()->id(),
-                        'movement_type' => 'salida',
-                        'quantity' => $qty,
-                        'concept' => 'Venta',
-                    ];
-                }
-            }
-
-            // Tragos
-            if ($request->drink_ids) {
-                foreach ($request->drink_ids as $index => $drinkId) {
-                    $drink = Drink::where('active', true)->find($drinkId);
-                    $qty = $request->drink_quantities[$index];
-                    if (!$drink) {
-                        DB::rollBack();
-                        $message = ['drink_ids' => ['Trago no disponible']];
-                        if ($request->expectsJson()) {
-                            return response()->json(['errors' => $message], 422);
-                        }
-                        return back()->withErrors($message)->withInput();
-                    }
-                    $price = $drink->price;
-                    $discount = Discount::where('discountable_type', Drink::class)
-                        ->where('discountable_id', $drinkId)
-                        ->where('active', true)
-                        ->where(function($q){
-                            $q->whereNull('start_at')->orWhere('start_at','<=', now());
-                        })
-                        ->where(function($q){ $q->whereNull('end_at')->orWhere('end_at','>', now()); })
-                        ->first();
-                    if ($discount && $discount->end_at && $discount->end_at->isPast()) {
-                        $discount->update(['active' => false]);
-                        $discount = null;
-                    }
-                    $discValue = 0;
-                    if ($discount) {
-                        $discValue = $discount->amount_type === 'fixed' ? $discount->amount : ($price * $discount->amount / 100);
-                        $price = max(0, $price - $discValue);
-                    }
-                    $subtotal = $price * $qty;
-
-                    $details[] = [
-                        'type' => 'drink',
-                        'service_id' => null,
-                        'product_id' => null,
-                        'drink_id' => $drinkId,
-                        'quantity' => $qty,
-                        'unit_price' => $price,
-                        'discount_amount' => $discValue,
-                        'subtotal' => $subtotal,
-                    ];
-
-                    $total += $subtotal;
-                    $discountTotal += $discValue * $qty;
-                }
-            }
-
-            if ($request->charge_descriptions) {
-                foreach ($request->charge_descriptions as $i => $desc) {
-                    $amount = floatval($request->charge_amounts[$i] ?? 0);
-                    if ($desc && $amount > 0) {
-                        $details[] = [
-                            'type' => 'extra',
-                            'service_id' => null,
-                            'product_id' => null,
-                            'drink_id' => null,
-                            'quantity' => 1,
-                            'unit_price' => $amount,
-                            'discount_amount' => 0,
-                            'subtotal' => $amount,
-                            'description' => $desc,
-                        ];
-                        $total += $amount;
-                    }
-                }
-            }
-
-            if (count($details) === 0) {
-                DB::rollBack();
-                $message = ['service_ids' => ['Debe agregar al menos un servicio, producto o trago']];
-                if ($request->expectsJson()) {
-                    return response()->json(['errors' => $message], 422);
-                }
-                return back()->withErrors($message)->withInput();
-            }
-
-            if (!$pending && $request->paid_amount < $total) {
-                DB::rollBack();
-                $message = ['paid_amount' => ['El monto pagado es menor al total a pagar']];
-                if ($request->expectsJson()) {
-                    return response()->json(['errors' => $message], 422);
-                }
-                return back()->withErrors($message)->withInput();
-            }
-
-            $vehicle = null;
-            if ($request->filled('plate')) {
-                $vehicle = Vehicle::where('plate', $request->plate)->first();
-                if (!$vehicle) {
-                    $vehicle = Vehicle::create([
-                        'customer_name' => $request->customer_name,
-                        'vehicle_type_id' => $request->vehicle_type_id,
-                        'plate' => $request->plate,
-                        'brand' => $request->brand,
-                        'model' => $request->model,
-                        'color' => $request->color,
-                        'year' => $request->year,
-                    ]);
-                } elseif (!$vehicle->year && $request->filled('year')) {
-                    $vehicle->update(['year' => $request->year]);
-                }
-            }
-
-            $ticket = Ticket::create([
-                'user_id' => auth()->id(),
-                'washer_id' => $request->washer_id,
-                'vehicle_type_id' => $request->vehicle_type_id,
-                'vehicle_id' => optional($vehicle)->id,
-                'customer_name' => $request->customer_name,
-                'customer_phone' => $request->customer_phone,
-                'total_amount' => $total,
-                'paid_amount' => $pending ? 0 : $request->paid_amount,
-                'change' => $pending ? 0 : ($request->paid_amount - $total),
-                'discount_total' => $discountTotal,
-                'payment_method' => $pending ? null : $request->payment_method,
-                'bank_account_id' => $pending ? null : $request->bank_account_id,
-                'washer_pending_amount' => $hasService ? 100 : 0,
-                'pending' => $pending,
-                'paid_at' => $pending ? null : $ticketDate,
-                'created_at' => $ticketDate,
-            ]);
-
-            foreach ($details as $detail) {
-                $detail['ticket_id'] = $ticket->id;
-                TicketDetail::create($detail);
-            }
-
-            foreach ($productMovements as $mov) {
-                $mov['ticket_id'] = $ticket->id;
-                InventoryMovement::create($mov);
-            }
-
-            if ($request->washer_id && $hasService) {
-                Washer::whereId($request->washer_id)->increment('pending_amount', 100);
-            }
-
-            DB::commit();
-
-            return redirect()->route('tickets.index')
-                ->with('success', 'Ticket generado correctamente.');
-
-        } catch (\Exception $e) {
-            DB::rollBack();
-            return back()->with('error', 'Error generando ticket: ' . $e->getMessage());
-        }
+        return $this->storeMultiple($request);
     }
 
     public function edit(Ticket $ticket)
@@ -579,12 +260,22 @@ class TicketController extends Controller
             return redirect()->route('tickets.index')->with('error', 'No se puede editar un ticket con más de 6 horas de creado.');
         }
 
-        $services = Service::where('active', true)->with('prices')->get();
+        $ticket->load(['washes.details.service']);
+
+        $services = Service::where('active', true)
+            ->with('prices.vehicleType')
+            ->orderBy('name')
+            ->get();
         $servicePrices = [];
         foreach ($services as $service) {
-            foreach ($service->prices as $price) {
-                $servicePrices[$service->id][$price->vehicle_type_id] = $price->price;
-            }
+            $servicePrices[$service->id] = $service->prices->map(function ($price) {
+                return [
+                    'id' => $price->id,
+                    'label' => $price->label ?? optional($price->vehicleType)->name ?? 'General',
+                    'price' => $price->price,
+                    'vehicle_type_id' => $price->vehicle_type_id,
+                ];
+            })->values();
         }
 
         $products = Product::where('stock', '>', 0)->orderBy('name')->get();
@@ -621,26 +312,39 @@ class TicketController extends Controller
         $ticketProducts = $ticket->details->where('type','product')->map(fn($d)=>['id'=>$d->product_id,'qty'=>$d->quantity]);
         $ticketDrinks = $ticket->details->where('type','drink')->map(fn($d)=>['id'=>$d->drink_id,'qty'=>$d->quantity]);
 
-        $ticketWashes = $ticket->washes->map(function($w) use ($servicePrices, $serviceDiscounts) {
-            $serviceIds = $w->details->where('type','service')->pluck('service_id');
-            $total = 0; $discount = 0;
-            foreach ($serviceIds as $sid) {
-                $price = $servicePrices[$sid][$w->vehicle_type_id] ?? 0;
-                if ($disc = ($serviceDiscounts[$sid] ?? null)) {
-                    $d = $disc['type'] === 'fixed' ? $disc['amount'] : $price * $disc['amount']/100;
-                    $discount += $d;
-                    $price = max(0, $price - $d);
-                }
-                $total += $price;
+        $ticketWashes = $ticket->washes->flatMap(function ($w) use ($servicePrices, $serviceDiscounts) {
+            $serviceDetails = $w->details->where('type', 'service');
+            if ($serviceDetails->isEmpty()) {
+                return collect();
             }
-            $total += $w->tip;
-            return [
-                'wash' => $w,
-                'service_ids' => $serviceIds,
-                'total' => $total,
-                'discount' => $discount,
-                'tip' => $w->tip,
-            ];
+
+            return $serviceDetails->values()->map(function ($detail, $index) use ($w, $servicePrices, $serviceDiscounts) {
+                $serviceId = $detail->service_id;
+                $options = $servicePrices[$serviceId] ?? collect();
+                $priceOption = $options->firstWhere('vehicle_type_id', $w->vehicle_type_id);
+                if (!$priceOption && $options instanceof \Illuminate\Support\Collection) {
+                    $priceOption = $options->first();
+                }
+
+                $price = $priceOption['price'] ?? $detail->unit_price;
+                $discount = 0;
+                if ($disc = ($serviceDiscounts[$serviceId] ?? null)) {
+                    $discount = $disc['type'] === 'fixed'
+                        ? $disc['amount']
+                        : ($price * $disc['amount'] / 100);
+                }
+
+                return [
+                    'wash' => $w,
+                    'service_id' => $serviceId,
+                    'service_price_id' => $priceOption['id'] ?? null,
+                    'service_name' => optional($detail->service)->name,
+                    'price_label' => $priceOption['label'] ?? null,
+                    'total' => $detail->subtotal + ($index === 0 ? $w->tip : 0),
+                    'discount' => $discount,
+                    'tip' => $index === 0 ? $w->tip : 0,
+                ];
+            });
         });
 
         $ticketExtras = $ticket->details->where('type','extra')->map(fn($d)=>[
@@ -651,7 +355,6 @@ class TicketController extends Controller
         return view('tickets.edit', [
             'ticket' => $ticket,
             'services' => $services,
-            'vehicleTypes' => VehicleType::all(),
             'products' => $products,
             'washers' => Washer::where('active', true)->orderBy('name')->get(),
             'bankAccounts' => BankAccount::all(),
@@ -672,352 +375,7 @@ class TicketController extends Controller
 
     public function update(Request $request, Ticket $ticket)
     {
-        if ($request->has('washes')) {
-            return $this->updateMultiple($request, $ticket);
-        }
-        if ($ticket->created_at->lt(now()->subHours(6)) && auth()->user()->role === 'cajero') {
-            return back()->with('error', 'No se puede editar un ticket con más de 6 horas de creado.');
-        }
-        if ($ticket->pending && $request->has('ticket_action')) {
-            $pending = $request->input('ticket_action') === 'pending';
-
-            $serviceIds = $request->input('service_ids', []);
-            $hasWash = Service::whereIn('id', $serviceIds)
-                ->where('name', 'like', 'Lavado%')->exists();
-
-            $rules = [
-                'customer_name' => ['required','regex:/^[A-Za-zÁÉÍÓÚáéíóúñÑ\s]+$/','max:255'],
-                'vehicle_type_id' => [$hasWash ? 'required' : 'nullable','exists:vehicle_types,id'],
-                'customer_phone' => ['nullable','regex:/^[0-9+()\s-]+$/','max:20'],
-                'plate' => [$hasWash ? 'required' : 'nullable','alpha_num','max:20'],
-                'brand' => [$hasWash ? 'required' : 'nullable','regex:/^[A-Za-z0-9\s]+$/','max:50'],
-                'model' => [$hasWash ? 'required' : 'nullable','regex:/^[A-Za-z0-9\s]+$/','max:50'],
-                'color' => [$hasWash ? 'required' : 'nullable','regex:/^[A-Za-zÁÉÍÓÚáéíóúñÑ\s]+$/','max:50'],
-                'year' => 'nullable|integer|between:1890,' . date('Y'),
-                'washer_id' => 'nullable|exists:washers,id',
-                'service_ids' => 'nullable|array',
-                'service_ids.*' => 'exists:services,id',
-                'product_ids' => 'nullable|array',
-                'product_ids.*' => 'exists:products,id',
-                'quantities' => 'nullable|array',
-                'quantities.*' => 'integer|min:1',
-                'drink_ids' => 'nullable|array',
-                'drink_ids.*' => 'exists:drinks,id',
-                'drink_quantities' => 'nullable|array',
-                'drink_quantities.*' => 'integer|min:1',
-                'ticket_date' => 'required|date|before_or_equal:today',
-            ];
-
-            if (!$pending) {
-                $rules['payment_method'] = 'required|in:efectivo,tarjeta,transferencia,mixto';
-                $rules['bank_account_id'] = 'required_if:payment_method,transferencia|nullable|exists:bank_accounts,id';
-                $rules['paid_amount'] = 'required|numeric|min:0';
-            }
-
-            $request->validate($rules, [
-                'ticket_date.before_or_equal' => 'La fecha del ticket no puede ser futura.'
-            ]);
-
-            DB::beginTransaction();
-            try {
-                $ticketDate = Carbon::parse($request->ticket_date)->setTimeFrom($ticket->created_at);
-                $oldService = $ticket->details()->where('type','service')->exists();
-                if ($oldService) {
-                    if ($ticket->washer_id) {
-                        Washer::whereId($ticket->washer_id)->decrement('pending_amount',100);
-                    } elseif ($ticket->washer_pending_amount > 0) {
-                        $ticket->washer_pending_amount = 0;
-                    }
-                }
-
-                foreach ($ticket->details as $det) {
-                    if ($det->type === 'product' && $det->product) {
-                        $det->product->increment('stock', $det->quantity);
-                        InventoryMovement::where('ticket_id',$ticket->id)
-                            ->where('product_id',$det->product_id)
-                            ->where('movement_type','salida')->delete();
-                    }
-                }
-
-                $ticket->details()->delete();
-
-                $vehicleType = $request->vehicle_type_id ? VehicleType::findOrFail($request->vehicle_type_id) : null;
-                $total = 0; $discountTotal = 0; $details = []; $productMovements = [];
-
-                foreach ($serviceIds as $serviceId) {
-                    $service = Service::where('active',true)->find($serviceId);
-                    if (!$service || !$vehicleType) continue;
-                    $priceRow = $service->prices()->where('vehicle_type_id',$vehicleType->id)->first();
-                    $price = $priceRow?->price ?? 0;
-                    $discount = Discount::where('discountable_type',Service::class)
-                        ->where('discountable_id',$serviceId)
-                        ->where('active',true)
-                        ->where(function($q){$q->whereNull('start_at')->orWhere('start_at','<=',now());})
-                        ->where(function($q){$q->whereNull('end_at')->orWhere('end_at','>',now());})
-                        ->first();
-                    $discValue = 0;
-                    if($discount){
-                        if($discount->end_at && $discount->end_at->isPast()){
-                            $discount->update(['active'=>false]);
-                        }else{
-                            $discValue = $discount->amount_type === 'fixed' ? $discount->amount : ($price * $discount->amount/100);
-                            $price = max(0,$price - $discValue);
-                        }
-                    }
-                    $details[] = [
-                        'type' => 'service',
-                        'service_id' => $serviceId,
-                        'product_id' => null,
-                        'quantity' => 1,
-                        'unit_price' => $price,
-                        'discount_amount' => $discValue,
-                        'subtotal' => $price,
-                    ];
-                    $total += $price; $discountTotal += $discValue; $hasWash = true;
-                }
-
-                if ($request->product_ids) {
-                    foreach ($request->product_ids as $index => $productId) {
-                        $product = Product::find($productId);
-                        $qty = $request->quantities[$index];
-                        if (!$product || $product->stock < $qty) {
-                            DB::rollBack();
-                            return back()->withErrors(['quantities' => ['Stock insuficiente para '.($product->name ?? 'producto')]])->withInput();
-                        }
-                        $price = $product->price;
-                        $discount = Discount::where('discountable_type',Product::class)
-                            ->where('discountable_id',$productId)
-                            ->where('active',true)
-                            ->where(function($q){$q->whereNull('start_at')->orWhere('start_at','<=',now());})
-                            ->where(function($q){$q->whereNull('end_at')->orWhere('end_at','>',now());})
-                            ->first();
-                        $discValue = 0;
-                        if($discount){
-                            if($discount->end_at && $discount->end_at->isPast()){
-                                $discount->update(['active'=>false]);
-                            }else{
-                                $discValue = $discount->amount_type==='fixed'? $discount->amount : ($price*$discount->amount/100);
-                                $price = max(0,$price - $discValue);
-                            }
-                        }
-                        $subtotal = $price * $qty;
-                        $details[] = [
-                            'type' => 'product',
-                            'service_id' => null,
-                            'product_id' => $productId,
-                            'quantity' => $qty,
-                            'unit_price' => $price,
-                            'discount_amount' => $discValue,
-                            'subtotal' => $subtotal,
-                        ];
-                        $total += $subtotal; $discountTotal += $discValue*$qty;
-                        $product->decrement('stock',$qty);
-                        $productMovements[] = [
-                            'product_id'=>$productId,
-                            'user_id'=>auth()->id(),
-                            'movement_type'=>'salida',
-                            'quantity'=>$qty,
-                            'concept'=>'Venta'
-                        ];
-                    }
-                }
-
-                if ($request->drink_ids) {
-                    foreach ($request->drink_ids as $index => $drinkId) {
-                        $drink = Drink::where('active',true)->find($drinkId);
-                        $qty = $request->drink_quantities[$index];
-                        if(!$drink){
-                            DB::rollBack();
-                            return back()->withErrors(['drink_ids'=>['Trago no disponible']])->withInput();
-                        }
-                        $price = $drink->price;
-                        $discount = Discount::where('discountable_type',Drink::class)
-                            ->where('discountable_id',$drinkId)
-                            ->where('active',true)
-                            ->where(function($q){$q->whereNull('start_at')->orWhere('start_at','<=',now());})
-                            ->where(function($q){$q->whereNull('end_at')->orWhere('end_at','>',now());})
-                            ->first();
-                        $discValue = 0;
-                        if($discount){
-                            if($discount->end_at && $discount->end_at->isPast()){
-                                $discount->update(['active'=>false]);
-                            }else{
-                                $discValue = $discount->amount_type==='fixed'? $discount->amount : ($price*$discount->amount/100);
-                                $price = max(0,$price - $discValue);
-                            }
-                        }
-                        $subtotal = $price*$qty;
-                        $details[] = [
-                            'type' => 'drink',
-                            'service_id' => null,
-                            'product_id' => null,
-                            'drink_id' => $drinkId,
-                            'quantity' => $qty,
-                            'unit_price' => $price,
-                            'discount_amount' => $discValue,
-                            'subtotal' => $subtotal,
-                        ];
-                        $total += $subtotal; $discountTotal += $discValue*$qty;
-                    }
-                }
-
-                if (count($details) === 0) {
-                    DB::rollBack();
-                    return back()->withErrors(['service_ids'=>['Debe agregar al menos un servicio, producto o trago']])->withInput();
-                }
-
-                if (!$pending && $request->paid_amount < $total) {
-                    DB::rollBack();
-                    return back()->withErrors(['paid_amount'=>['El monto pagado es menor al total a pagar']])->withInput();
-                }
-
-                $vehicle = null;
-                if ($request->filled('plate')) {
-                    $vehicle = Vehicle::where('plate',$request->plate)->first();
-                    if(!$vehicle){
-                        $vehicle = Vehicle::create([
-                            'customer_name'=>$request->customer_name,
-                            'vehicle_type_id'=>$request->vehicle_type_id,
-                            'plate'=>$request->plate,
-                            'brand'=>$request->brand,
-                            'model'=>$request->model,
-                            'color'=>$request->color,
-                            'year'=>$request->year,
-                        ]);
-                    } elseif(!$vehicle->year && $request->filled('year')) {
-                        $vehicle->update(['year'=>$request->year]);
-                    }
-                }
-
-                $ticket->update([
-                    'washer_id' => $request->washer_id,
-                    'vehicle_type_id' => $request->vehicle_type_id,
-                    'vehicle_id' => optional($vehicle)->id,
-                    'customer_name' => $request->customer_name,
-                    'customer_phone' => $request->customer_phone,
-                    'total_amount' => $total,
-                    'paid_amount' => $pending ? 0 : $request->paid_amount,
-                    'change' => $pending ? 0 : ($request->paid_amount - $total),
-                    'discount_total' => $discountTotal,
-                    'payment_method' => $pending ? null : $request->payment_method,
-                    'bank_account_id' => $pending ? null : $request->bank_account_id,
-                    'washer_pending_amount' => $hasWash ? 100 : 0,
-                    'pending' => $pending,
-                    'paid_at' => $pending ? null : $ticketDate,
-                    'created_at' => $ticketDate,
-                ]);
-
-                foreach ($details as $detail) {
-                    $detail['ticket_id'] = $ticket->id;
-                    TicketDetail::create($detail);
-                }
-
-                foreach ($productMovements as $mov) {
-                    $mov['ticket_id'] = $ticket->id;
-                    InventoryMovement::create($mov);
-                }
-
-                if ($request->washer_id && $hasWash) {
-                    Washer::whereId($request->washer_id)->increment('pending_amount',100);
-                }
-
-                DB::commit();
-
-                return redirect()->route('tickets.index')->with('success','Ticket actualizado.');
-            } catch (\Exception $e) {
-                DB::rollBack();
-                return back()->with('error','Error actualizando ticket: '.$e->getMessage());
-            }
-        }
-
-        $request->validate([
-            'washers' => 'nullable|array',
-            'washers.*' => 'nullable|exists:washers,id',
-            'payment_method' => 'required|in:efectivo,tarjeta,transferencia,mixto',
-            'bank_account_id' => 'required_if:payment_method,transferencia|nullable|exists:bank_accounts,id',
-        ]);
-
-        foreach ($ticket->washes as $wash) {
-            $new = $request->input('washers.' . $wash->id) ?: null;
-            if (! $ticket->pending) {
-                $tipPaid = WasherMovement::where('ticket_id', $ticket->id)
-                    ->where('washer_id', $wash->washer_id)
-                    ->where('description', 'like', '[P]%')
-                    ->where('paid', true)
-                    ->exists();
-                if (($wash->washer_paid || $tipPaid) && $new != $wash->washer_id) {
-                    return back()->withErrors(['washers' => 'No se puede cambiar el lavador porque ya fue pagado.']);
-                }
-            }
-        }
-
-        DB::transaction(function() use ($ticket, $request) {
-            foreach ($ticket->washes as $wash) {
-                $hasService = $wash->details()->where('type','service')->exists();
-                $old = $wash->washer_id;
-                $new = $request->input('washers.' . $wash->id) ?: null;
-                $tip = $wash->tip;
-                if ($hasService && $old != $new) {
-                    if ($old) {
-                        Washer::whereId($old)->decrement('pending_amount',100 + $tip);
-                        if ($tip > 0) {
-                            $movement = WasherMovement::where('ticket_id', $ticket->id)
-                                ->where('washer_id', $old)
-                                ->where('description', 'like', '[P]%')
-                                ->first();
-                            if ($movement) {
-                                if ($movement->paid) {
-                                    WasherMovement::create([
-                                        'washer_id' => $old,
-                                        'ticket_id' => $ticket->id,
-                                        'amount' => -$movement->amount,
-                                        'description' => 'Cuenta por cobrar - Propina de ticket cancelado',
-                                    ]);
-                                }
-                                $movement->delete();
-                            }
-                        }
-                    } else {
-                        $ticket->washer_pending_amount = max(0, $ticket->washer_pending_amount - (100 + $tip));
-                    }
-                    if ($new) {
-                        Washer::whereId($new)->increment('pending_amount',100 + $tip);
-                        if ($tip > 0) {
-                            $vehicle = $wash->vehicle;
-                            $parts = [];
-                            if ($vehicle) {
-                                $parts[] = $vehicle->brand;
-                                $parts[] = $vehicle->model;
-                                $parts[] = $vehicle->color;
-                                $parts[] = $vehicle->year;
-                            }
-                            $parts[] = optional($wash->vehicleType)->name;
-                            WasherMovement::create([
-                                'washer_id' => $new,
-                                'ticket_id' => $ticket->id,
-                                'amount' => $tip,
-                                'description' => '[P] '.implode(' | ', array_filter($parts)),
-                                'created_at' => $ticket->created_at,
-                                'updated_at' => $ticket->created_at,
-                            ]);
-                        }
-                    } else {
-                        $ticket->washer_pending_amount += 100 + $tip;
-                    }
-                    $wash->washer_id = $new;
-                    $wash->washer_paid = false;
-                    $wash->save();
-                }
-            }
-
-            $ticket->update([
-                'payment_method' => $request->payment_method,
-                'bank_account_id' => $request->bank_account_id,
-                'washer_pending_amount' => $ticket->washer_pending_amount,
-            ]);
-        });
-
-        return redirect()->route('tickets.index')->with('success', 'Ticket actualizado.');
+        return $this->updateMultiple($request, $ticket);
     }
 
     public function destroy(Ticket $ticket)
@@ -1197,15 +555,9 @@ class TicketController extends Controller
             'customer_phone' => ['nullable','regex:/^[0-9+()\s-]+$/','max:20'],
             'ticket_date' => 'required|date|before_or_equal:today',
             'washes' => ['required','array','min:1'],
-            'washes.*.vehicle_type_id' => ['required','exists:vehicle_types,id'],
-            'washes.*.plate' => ['required','alpha_num','max:20'],
-            'washes.*.brand' => ['required','regex:/^[A-Za-z0-9\s]+$/','max:50'],
-            'washes.*.model' => ['required','regex:/^[A-Za-z0-9\s]+$/','max:50'],
-            'washes.*.color' => ['required','regex:/^[A-Za-zÁÉÍÓÚáéíóúñÑ\s]+$/','max:50'],
-            'washes.*.year' => 'nullable|integer|between:1890,' . date('Y'),
+            'washes.*.service_id' => ['required','exists:services,id'],
+            'washes.*.service_price_id' => ['required','exists:service_prices,id'],
             'washes.*.washer_id' => 'nullable|exists:washers,id',
-            'washes.*.service_ids' => ['required','array','min:1'],
-            'washes.*.service_ids.*' => ['exists:services,id'],
             'washes.*.tip' => ['nullable','numeric','min:0'],
             'product_ids' => 'nullable|array',
             'product_ids.*' => 'exists:products,id',
@@ -1225,7 +577,11 @@ class TicketController extends Controller
             $rules['bank_account_id'] = 'required_if:payment_method,transferencia|nullable|exists:bank_accounts,id';
             $rules['paid_amount'] = 'required|numeric|min:0';
         }
-        $request->validate($rules);
+        $messages = [
+            'washes.*.service_price_id.required' => 'Debe seleccionar una opción de precio.',
+            'washes.*.service_price_id.exists' => 'La opción de precio seleccionada no es válida.',
+        ];
+        $request->validate($rules, $messages);
 
         DB::beginTransaction();
         try {
@@ -1234,17 +590,24 @@ class TicketController extends Controller
             $washerPendingAmount = 0; $washInfo = [];
 
             foreach ($ticket->washes as $oldWash) {
-                $has = $oldWash->details()->where('type','service')->exists();
+                $serviceDetail = $oldWash->details->firstWhere('type', 'service');
+                $hasService = $serviceDetail !== null;
                 $tipOld = $oldWash->tip;
-                if ($has && $oldWash->washer_id) {
-                    Washer::whereId($oldWash->washer_id)->decrement('pending_amount',100 + $tipOld);
+
+                if ($hasService && $oldWash->washer_id) {
+                    Washer::whereId($oldWash->washer_id)->decrement('pending_amount', 100 + $tipOld);
+
                     if ($tipOld > 0) {
-                        WasherMovement::where('ticket_id',$ticket->id)
-                            ->where('washer_id',$oldWash->washer_id)
-                            ->where('description','like','[P]%')
+                        $serviceName = optional($serviceDetail->service)->name;
+                        $label = optional($oldWash->vehicleType)->name;
+                        $description = '[P] '.$serviceName.($label ? ' | '.$label : '');
+
+                        WasherMovement::where('ticket_id', $ticket->id)
+                            ->where('washer_id', $oldWash->washer_id)
+                            ->where('description', $description)
                             ->delete();
                     }
-                } elseif ($has) {
+                } elseif ($hasService) {
                     $ticket->washer_pending_amount = max(0, $ticket->washer_pending_amount - (100 + $tipOld));
                 }
             }
@@ -1260,40 +623,91 @@ class TicketController extends Controller
             $ticket->washes()->delete();
 
             foreach ($request->washes as $wash) {
-                $vehicleType = VehicleType::find($wash['vehicle_type_id']);
-                if (!$vehicleType) continue;
-                $washDetails = []; $hasService = false;
-                $tip = isset($wash['tip']) ? floatval($wash['tip']) : 0;
-                foreach ($wash['service_ids'] as $serviceId) {
-                    $service = Service::where('active',true)->find($serviceId);
-                    if(!$service) continue;
-                    $priceRow = $service->prices()->where('vehicle_type_id',$vehicleType->id)->first();
-                    $price = $priceRow?->price ?? 0;
-                    $discount = Discount::where('discountable_type',Service::class)
-                        ->where('discountable_id',$serviceId)
-                        ->where('active',true)
-                        ->where(function($q){$q->whereNull('start_at')->orWhere('start_at','<=',now());})
-                        ->where(function($q){$q->whereNull('end_at')->orWhere('end_at','>',now());})
-                        ->first();
-                    $discValue = 0;
-                    if($discount){
-                        if($discount->end_at && $discount->end_at->isPast()){
-                            $discount->update(['active'=>false]);
-                        }else{
-                            $discValue = $discount->amount_type==='fixed'? $discount->amount : ($price*$discount->amount/100);
-                            $price = max(0,$price-$discValue);
-                        }
-                    }
-                    $washDetails[]=[
-                        'type'=>'service','service_id'=>$serviceId,'product_id'=>null,
-                        'quantity'=>1,'unit_price'=>$price,'discount_amount'=>$discValue,'subtotal'=>$price
-                    ];
-                    $total += $price; $discountTotal += $discValue; $hasService = true;
+                $service = Service::where('active', true)
+                    ->with('prices.vehicleType')
+                    ->find($wash['service_id']);
+
+                if (!$service) {
+                    continue;
                 }
-                $total += $tip;
-                if(empty($wash['washer_id']) && $hasService){ $washerPendingAmount += 100 + $tip; }
-                $wash['tip'] = $tip;
-                $washInfo[]=['data'=>$wash,'details'=>$washDetails,'has_service'=>$hasService,'vehicle_type_name'=>$vehicleType->name ?? ''];
+
+                $prices = $service->prices;
+                if ($prices->isEmpty()) {
+                    DB::rollBack();
+                    $message = ['washes' => ['El servicio seleccionado no tiene opciones de precio configuradas.']];
+                    if ($request->expectsJson()) {
+                        return response()->json(['errors' => $message], 422);
+                    }
+                    return back()->withErrors($message)->withInput();
+                }
+
+                $priceOption = $prices->firstWhere('id', (int) $wash['service_price_id']);
+                if (!$priceOption) {
+                    DB::rollBack();
+                    $message = ['washes' => ['Debe seleccionar una opción de precio válida para cada servicio.']];
+                    if ($request->expectsJson()) {
+                        return response()->json(['errors' => $message], 422);
+                    }
+                    return back()->withErrors($message)->withInput();
+                }
+
+                $price = $priceOption->price;
+                $discount = Discount::where('discountable_type', Service::class)
+                    ->where('discountable_id', $service->id)
+                    ->where('active', true)
+                    ->where(function ($q) {
+                        $q->whereNull('start_at')->orWhere('start_at', '<=', now());
+                    })
+                    ->where(function ($q) {
+                        $q->whereNull('end_at')->orWhere('end_at', '>', now());
+                    })
+                    ->first();
+
+                if ($discount && $discount->end_at && $discount->end_at->isPast()) {
+                    $discount->update(['active' => false]);
+                    $discount = null;
+                }
+
+                $discValue = 0;
+                if ($discount) {
+                    $discValue = $discount->amount_type === 'fixed'
+                        ? $discount->amount
+                        : ($price * $discount->amount / 100);
+                    $price = max(0, $price - $discValue);
+                }
+
+                $tip = isset($wash['tip']) ? floatval($wash['tip']) : 0;
+
+                $washDetails = [[
+                    'type' => 'service',
+                    'service_id' => $service->id,
+                    'product_id' => null,
+                    'quantity' => 1,
+                    'unit_price' => $price,
+                    'discount_amount' => $discValue,
+                    'subtotal' => $price,
+                ]];
+
+                $total += $price + $tip;
+                $discountTotal += $discValue;
+
+                if (empty($wash['washer_id'])) {
+                    $washerPendingAmount += 100 + $tip;
+                }
+
+                $washInfo[] = [
+                    'data' => [
+                        'service_id' => $service->id,
+                        'service_price_id' => $priceOption->id,
+                        'vehicle_type_id' => $priceOption->vehicle_type_id,
+                        'price_label' => $priceOption->label ?? optional($priceOption->vehicleType)->name,
+                        'service_name' => $service->name,
+                        'washer_id' => $wash['washer_id'] ?? null,
+                        'tip' => $tip,
+                    ],
+                    'details' => $washDetails,
+                    'has_service' => true,
+                ];
             }
 
             if($request->product_ids){
@@ -1397,23 +811,9 @@ class TicketController extends Controller
 
             foreach($washInfo as $info){
                 $washData=$info['data'];
-                $vehicle=Vehicle::where('plate',$washData['plate'])->first();
-                if(!$vehicle){
-                    $vehicle=Vehicle::create([
-                        'customer_name'=>$request->customer_name,
-                        'vehicle_type_id'=>$washData['vehicle_type_id'],
-                        'plate'=>$washData['plate'],
-                        'brand'=>$washData['brand'],
-                        'model'=>$washData['model'],
-                        'color'=>$washData['color'],
-                        'year'=>$washData['year'] ?? null,
-                    ]);
-                }elseif(!$vehicle->year && !empty($washData['year'])){
-                    $vehicle->update(['year'=>$washData['year']]);
-                }
                 $wash = TicketWash::create([
                     'ticket_id'=>$ticket->id,
-                    'vehicle_id'=>$vehicle->id,
+                    'vehicle_id'=>null,
                     'vehicle_type_id'=>$washData['vehicle_type_id'],
                     'washer_id'=>$washData['washer_id'] ?: null,
                     'washer_paid'=>false,
@@ -1428,18 +828,11 @@ class TicketController extends Controller
                     $increment = 100 + $washData['tip'];
                     Washer::whereId($washData['washer_id'])->increment('pending_amount',$increment);
                     if($washData['tip'] > 0){
-                        $parts = [
-                            $washData['brand'],
-                            $washData['model'],
-                            $washData['color'],
-                            $washData['year'],
-                            $info['vehicle_type_name'],
-                        ];
                         WasherMovement::create([
                             'washer_id'=>$washData['washer_id'],
                             'ticket_id'=>$ticket->id,
                             'amount'=>$washData['tip'],
-                            'description'=>'[P] '.implode(' | ', array_filter($parts)),
+                            'description'=>'[P] '.$washData['service_name'].($washData['price_label'] ? ' | '.$washData['price_label'] : ''),
                             'created_at'=>$ticketDate,
                             'updated_at'=>$ticketDate,
                         ]);
@@ -1472,15 +865,10 @@ class TicketController extends Controller
             'customer_phone' => ['nullable','regex:/^[0-9+()\s-]+$/','max:20'],
             'ticket_date' => 'required|date|before_or_equal:today',
             'washes' => ['required','array','min:1'],
-            'washes.*.vehicle_type_id' => ['required','exists:vehicle_types,id'],
-            'washes.*.plate' => ['required','alpha_num','max:20'],
-            'washes.*.brand' => ['required','regex:/^[A-Za-z0-9\s]+$/','max:50'],
-            'washes.*.model' => ['required','regex:/^[A-Za-z0-9\s]+$/','max:50'],
-            'washes.*.color' => ['required','regex:/^[A-Za-zÁÉÍÓÚáéíóúñÑ\s]+$/','max:50'],
-            'washes.*.year' => 'nullable|integer|between:1890,' . date('Y'),
+            'washes.*.service_id' => ['required','exists:services,id'],
+            'washes.*.service_price_id' => ['required','exists:service_prices,id'],
             'washes.*.washer_id' => 'nullable|exists:washers,id',
-            'washes.*.service_ids' => ['required','array','min:1'],
-            'washes.*.service_ids.*' => ['exists:services,id'],
+            'washes.*.tip' => ['nullable','numeric','min:0'],
             'product_ids' => 'nullable|array',
             'product_ids.*' => 'exists:products,id',
             'quantities' => 'nullable|array',
@@ -1489,6 +877,10 @@ class TicketController extends Controller
             'drink_ids.*' => 'exists:drinks,id',
             'drink_quantities' => 'nullable|array',
             'drink_quantities.*' => 'integer|min:1',
+            'charge_descriptions' => 'nullable|array',
+            'charge_descriptions.*' => 'nullable|string|max:255',
+            'charge_amounts' => 'nullable|array',
+            'charge_amounts.*' => 'numeric|min:0',
         ];
 
         if (!$pending) {
@@ -1505,20 +897,14 @@ class TicketController extends Controller
             'ticket_date.required' => 'La fecha del ticket es obligatoria.',
             'ticket_date.date' => 'La fecha del ticket no es válida.',
             'ticket_date.before_or_equal' => 'La fecha del ticket no puede ser futura.',
-            'washes.required' => 'Debe agregar al menos un lavado.',
-            'washes.*.vehicle_type_id.required' => 'El tipo de vehículo es obligatorio.',
-            'washes.*.vehicle_type_id.exists' => 'El tipo de vehículo seleccionado no es válido.',
-            'washes.*.plate.required' => 'La placa es obligatoria.',
-            'washes.*.plate.alpha_num' => 'La placa solo puede contener letras y numeros.',
-            'washes.*.brand.required' => 'La marca es obligatoria.',
-            'washes.*.brand.regex' => 'La marca solo puede contener letras y numeros.',
-            'washes.*.model.required' => 'El modelo es obligatorio.',
-            'washes.*.model.regex' => 'El modelo solo puede contener letras y numeros.',
-            'washes.*.color.required' => 'El color es obligatorio.',
-            'washes.*.color.regex' => 'El color solo puede contener letras.',
-            'washes.*.washer_id.exists' => 'El lavador seleccionado no es válido.',
-            'washes.*.service_ids.required' => 'Debe seleccionar al menos un servicio.',
-            'washes.*.service_ids.*.exists' => 'Alguno de los servicios seleccionados es inválido.',
+            'washes.required' => 'Debe agregar al menos un servicio.',
+            'washes.*.service_id.required' => 'Debe seleccionar un servicio.',
+            'washes.*.service_id.exists' => 'El servicio seleccionado no es válido.',
+            'washes.*.service_price_id.required' => 'Debe seleccionar una opción de precio.',
+            'washes.*.service_price_id.exists' => 'La opción de precio seleccionada no es válida.',
+            'washes.*.washer_id.exists' => 'El estilista seleccionado no es válido.',
+            'washes.*.tip.numeric' => 'La propina debe ser un número válido.',
+            'washes.*.tip.min' => 'La propina no puede ser negativa.',
             'product_ids.*.exists' => 'Alguno de los productos seleccionados es inválido.',
             'quantities.*.min' => 'La cantidad debe ser al menos 1.',
             'drink_ids.*.exists' => 'Alguno de los tragos seleccionados es inválido.',
@@ -1541,45 +927,91 @@ class TicketController extends Controller
             $washerPendingAmount = 0; $washInfo = [];
 
             foreach ($request->washes as $wash) {
-                $vehicleType = VehicleType::find($wash['vehicle_type_id']);
-                if (!$vehicleType) { continue; }
-                $washDetails = []; $hasService = false;
-                $tip = isset($wash['tip']) ? floatval($wash['tip']) : 0;
-                foreach ($wash['service_ids'] as $serviceId) {
-                    $service = Service::where('active', true)->find($serviceId);
-                    if (!$service) { continue; }
-                    $priceRow = $service->prices()->where('vehicle_type_id', $vehicleType->id)->first();
-                    $price = $priceRow ? $priceRow->price : 0;
-                    $discount = Discount::where('discountable_type', Service::class)
-                        ->where('discountable_id', $serviceId)
-                        ->where('active', true)
-                        ->where(function($q){ $q->whereNull('start_at')->orWhere('start_at','<=', now()); })
-                        ->where(function($q){ $q->whereNull('end_at')->orWhere('end_at','>', now()); })
-                        ->first();
-                    if ($discount && $discount->end_at && $discount->end_at->isPast()) {
-                        $discount->update(['active' => false]);
-                        $discount = null;
-                    }
-                    $discValue = 0;
-                    if ($discount) {
-                        $discValue = $discount->amount_type === 'fixed' ? $discount->amount : ($price * $discount->amount / 100);
-                        $price = max(0, $price - $discValue);
-                    }
-                    $washDetails[] = [
-                        'type' => 'service',
-                        'service_id' => $serviceId,
-                        'product_id' => null,
-                        'quantity' => 1,
-                        'unit_price' => $price,
-                        'discount_amount' => $discValue,
-                        'subtotal' => $price,
-                    ];
-                    $total += $price; $discountTotal += $discValue; $hasService = true;
+                $service = Service::where('active', true)
+                    ->with('prices.vehicleType')
+                    ->find($wash['service_id']);
+
+                if (!$service) {
+                    continue;
                 }
-                $total += $tip;
-                if (empty($wash['washer_id']) && $hasService) { $washerPendingAmount += 100 + $tip; }
-                $wash['tip'] = $tip;
-                $washInfo[] = ['data' => $wash, 'details' => $washDetails, 'has_service' => $hasService, 'vehicle_type_name' => $vehicleType->name ?? ''];
+
+                $prices = $service->prices;
+                if ($prices->isEmpty()) {
+                    DB::rollBack();
+                    $message = ['washes' => ['El servicio seleccionado no tiene opciones de precio configuradas.']];
+                    if ($request->expectsJson()) {
+                        return response()->json(['errors' => $message], 422);
+                    }
+                    return back()->withErrors($message)->withInput();
+                }
+
+                $priceOption = $prices->firstWhere('id', (int) $wash['service_price_id']);
+                if (!$priceOption) {
+                    DB::rollBack();
+                    $message = ['washes' => ['Debe seleccionar una opción de precio válida para cada servicio.']];
+                    if ($request->expectsJson()) {
+                        return response()->json(['errors' => $message], 422);
+                    }
+                    return back()->withErrors($message)->withInput();
+                }
+
+                $price = $priceOption->price;
+                $discount = Discount::where('discountable_type', Service::class)
+                    ->where('discountable_id', $service->id)
+                    ->where('active', true)
+                    ->where(function ($q) {
+                        $q->whereNull('start_at')->orWhere('start_at', '<=', now());
+                    })
+                    ->where(function ($q) {
+                        $q->whereNull('end_at')->orWhere('end_at', '>', now());
+                    })
+                    ->first();
+
+                if ($discount && $discount->end_at && $discount->end_at->isPast()) {
+                    $discount->update(['active' => false]);
+                    $discount = null;
+                }
+
+                $discValue = 0;
+                if ($discount) {
+                    $discValue = $discount->amount_type === 'fixed'
+                        ? $discount->amount
+                        : ($price * $discount->amount / 100);
+                    $price = max(0, $price - $discValue);
+                }
+
+                $tip = isset($wash['tip']) ? floatval($wash['tip']) : 0;
+
+                $detail = [
+                    'type' => 'service',
+                    'service_id' => $service->id,
+                    'product_id' => null,
+                    'quantity' => 1,
+                    'unit_price' => $price,
+                    'discount_amount' => $discValue,
+                    'subtotal' => $price,
+                ];
+
+                $total += $price + $tip;
+                $discountTotal += $discValue;
+
+                if (empty($wash['washer_id'])) {
+                    $washerPendingAmount += 100 + $tip;
+                }
+
+                $washInfo[] = [
+                    'data' => [
+                        'service_id' => $service->id,
+                        'service_price_id' => $priceOption->id,
+                        'vehicle_type_id' => $priceOption->vehicle_type_id,
+                        'price_label' => $priceOption->label ?? optional($priceOption->vehicleType)->name,
+                        'service_name' => $service->name,
+                        'washer_id' => $wash['washer_id'] ?? null,
+                        'tip' => $tip,
+                    ],
+                    'details' => [$detail],
+                    'has_service' => true,
+                ];
             }
 
             if ($request->product_ids) {
@@ -1736,24 +1168,10 @@ class TicketController extends Controller
 
             foreach ($washInfo as $info) {
                 $washData = $info['data'];
-                $vehicle = Vehicle::where('plate', $washData['plate'])->first();
-                if (!$vehicle) {
-                    $vehicle = Vehicle::create([
-                        'customer_name' => $request->customer_name,
-                        'vehicle_type_id' => $washData['vehicle_type_id'],
-                        'plate' => $washData['plate'],
-                        'brand' => $washData['brand'],
-                        'model' => $washData['model'],
-                        'color' => $washData['color'],
-                        'year' => $washData['year'] ?? null,
-                    ]);
-                } elseif (!$vehicle->year && !empty($washData['year'])) {
-                    $vehicle->update(['year' => $washData['year']]);
-                }
 
                 $wash = TicketWash::create([
                     'ticket_id' => $ticket->id,
-                    'vehicle_id' => $vehicle->id,
+                    'vehicle_id' => null,
                     'vehicle_type_id' => $washData['vehicle_type_id'],
                     'washer_id' => $washData['washer_id'] ?: null,
                     'washer_paid' => false,
@@ -1770,18 +1188,12 @@ class TicketController extends Controller
                     $increment = 100 + $washData['tip'];
                     Washer::whereId($washData['washer_id'])->increment('pending_amount', $increment);
                     if ($washData['tip'] > 0) {
-                        $parts = [
-                            $washData['brand'],
-                            $washData['model'],
-                            $washData['color'],
-                            $washData['year'],
-                            $info['vehicle_type_name'],
-                        ];
                         WasherMovement::create([
                             'washer_id' => $washData['washer_id'],
                             'ticket_id' => $ticket->id,
                             'amount' => $washData['tip'],
-                            'description' => '[P] '.implode(' | ', array_filter($parts)),
+                            'description' => '[P] '.$washData['service_name'].
+                                ($washData['price_label'] ? ' | '.$washData['price_label'] : ''),
                             'created_at' => $ticketDate,
                             'updated_at' => $ticketDate,
                         ]);

--- a/app/Http/Controllers/WasherController.php
+++ b/app/Http/Controllers/WasherController.php
@@ -112,7 +112,7 @@ class WasherController extends Controller
         ]);
 
         return redirect()->route('washers.index')
-            ->with('success', 'Lavador creado correctamente.');
+            ->with('success', 'Estilista creado correctamente.');
     }
 
     public function edit(Washer $washer)
@@ -133,7 +133,7 @@ class WasherController extends Controller
         ]);
 
         return redirect()->route('washers.index')
-            ->with('success', 'Lavador actualizado correctamente.');
+            ->with('success', 'Estilista actualizado correctamente.');
     }
 
     public function destroy(Washer $washer)
@@ -141,7 +141,7 @@ class WasherController extends Controller
         $washer->delete();
 
         return redirect()->route('washers.index')
-            ->with('success', 'Lavador eliminado correctamente.');
+            ->with('success', 'Estilista eliminado correctamente.');
     }
 
     public function show(Request $request, Washer $washer)

--- a/app/Models/ServicePrice.php
+++ b/app/Models/ServicePrice.php
@@ -9,7 +9,7 @@ class ServicePrice extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['service_id', 'vehicle_type_id', 'price'];
+    protected $fillable = ['service_id', 'vehicle_type_id', 'label', 'price'];
 
     public function service()
     {

--- a/app/Models/VehicleType.php
+++ b/app/Models/VehicleType.php
@@ -20,5 +20,10 @@ class VehicleType extends Model
     {
         return $this->hasMany(Ticket::class);
     }
+
+    public function vehicles()
+    {
+        return $this->hasMany(Vehicle::class);
+    }
 }
 

--- a/database/migrations/2025_09_01_000000_add_label_to_service_prices_table.php
+++ b/database/migrations/2025_09_01_000000_add_label_to_service_prices_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('service_prices', function (Blueprint $table) {
+            $table->string('label')->after('service_id');
+        });
+
+        DB::table('service_prices')
+            ->join('vehicle_types', 'service_prices.vehicle_type_id', '=', 'vehicle_types.id')
+            ->update(['label' => DB::raw('vehicle_types.name')]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('service_prices', function (Blueprint $table) {
+            $table->dropColumn('label');
+        });
+    }
+};

--- a/database/migrations/2025_09_01_000100_update_vehicle_types_unique_constraint.php
+++ b/database/migrations/2025_09_01_000100_update_vehicle_types_unique_constraint.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('vehicle_types', function (Blueprint $table) {
+            $table->dropUnique('vehicle_types_name_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('vehicle_types', function (Blueprint $table) {
+            $table->unique('name');
+        });
+    }
+};

--- a/database/seeders/ServicePriceSeeder.php
+++ b/database/seeders/ServicePriceSeeder.php
@@ -40,7 +40,7 @@ class ServicePriceSeeder extends Seeder
 
                 ServicePrice::updateOrCreate(
                     ['service_id' => $service->id, 'vehicle_type_id' => $vehicle->id],
-                    ['price' => $price]
+                    ['label' => $vehicle->name, 'price' => $price]
                 );
             }
         }

--- a/resources/views/dashboard/partials/summary.blade.php
+++ b/resources/views/dashboard/partials/summary.blade.php
@@ -45,7 +45,7 @@
                     @foreach($washerDebts as $w)
                         <tr>
                             <td class="border px-2 py-1">{{ $w->created_at->format('d/m h:i A') }}</td>
-                            <td class="border px-2 py-1">Lavador - {{ $w->washer->name }}</td>
+                            <td class="border px-2 py-1">Estilista - {{ $w->washer->name }}</td>
                             <td class="border px-2 py-1">{{ $w->description }}</td>
                             <td class="border px-2 py-1 text-right">RD$ {{ number_format(abs($w->amount),2) }}</td>
                         </tr>
@@ -60,7 +60,7 @@
             <p>Total facturado: <strong>RD$ {{ number_format($invoicedTotal, 2) }}</strong></p>
             <p>Caja chica: <strong>RD$ {{ number_format($pettyCashAmount, 2) }}</strong></p>
             <p>Gastos de caja chica: <strong>RD$ {{ number_format($pettyCashTotal, 2) }}</strong></p>
-            <p>Para lavadores: <strong>RD$ {{ number_format($washerPayDue, 2) }}</strong></p>
+            <p>Para estilistas: <strong>RD$ {{ number_format($washerPayDue, 2) }}</strong></p>
             <p>Ventas de lavados: RD$ {{ number_format($serviceTotal, 2) }}</p>
             <p>Ventas de productos: RD$ {{ number_format($productTotal, 2) }}</p>
             <p>Ventas de tragos: RD$ {{ number_format($drinkTotal, 2) }}</p>

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -17,7 +17,7 @@
                 <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5V4H2v16h5m0 0v-2.5A2.5 2.5 0 0 1 9.5 15h5a2.5 2.5 0 0 1 2.5 2.5V20m-10 0h10" />
                 </svg>
-                Lavadores
+                Estilistas
             </a>
             <div x-data="{ open: {{ request()->routeIs('services.*','products.*','drinks.*') ? 'true' : 'false' }} }">
                 <button type="button" @click="open=!open" class="w-full text-left px-3 py-2 font-semibold rounded hover:bg-gray-100 {{ request()->routeIs('services.*','products.*','drinks.*') ? 'bg-gray-200' : '' }}">

--- a/resources/views/services/create.blade.php
+++ b/resources/views/services/create.blade.php
@@ -7,40 +7,97 @@
 
     <div class="py-4">
         <div class="max-w-4xl mx-auto sm:px-6 lg:px-8 bg-white p-6 shadow sm:rounded-lg">
-        <form action="{{ route('services.store') }}" method="POST" class="space-y-6">
-            @csrf
+            <form action="{{ route('services.store') }}" method="POST" class="space-y-6">
+                @csrf
 
-            <div>
-                <label for="name" class="block font-medium text-sm text-gray-700">Nombre</label>
-                <input type="text" name="name" required class="form-input w-full">
-            </div>
+                <div>
+                    <label for="name" class="block font-medium text-sm text-gray-700">Nombre</label>
+                    <input type="text" name="name" required class="form-input w-full">
+                </div>
 
-           <div>
-               <label for="description" class="block font-medium text-sm text-gray-700">Descripción</label>
-               <textarea name="description" class="form-input w-full"></textarea>
-           </div>
+                <div>
+                    <label for="description" class="block font-medium text-sm text-gray-700">Descripción</label>
+                    <textarea name="description" class="form-input w-full"></textarea>
+                </div>
 
-            <div>
-                <label class="block font-medium text-sm text-gray-700 mb-1">Precios por tipo de vehículo</label>
-                @foreach ($vehicleTypes as $type)
-                    <div class="flex items-center gap-2 mb-1">
-                        <span class="w-32">{{ $type->name }}</span>
-                        <input type="number" name="prices[{{ $type->id }}]" step="0.01" required class="form-input w-full">
+                <div>
+                    <label class="block font-medium text-sm text-gray-700 mb-2">Tipos de precio</label>
+                    <div id="price-options" class="space-y-3">
+                        <div class="price-row flex flex-wrap items-end gap-2">
+                            <div class="flex-1 min-w-[200px]">
+                                <label class="block text-xs text-gray-600 uppercase tracking-wide">Nombre</label>
+                                <input type="text" name="price_options[0][label]" class="form-input w-full" required>
+                            </div>
+                            <div class="w-40">
+                                <label class="block text-xs text-gray-600 uppercase tracking-wide">Precio</label>
+                                <input type="number" name="price_options[0][price]" step="0.01" class="form-input w-full" required>
+                            </div>
+                            <button type="button" class="remove-price text-sm text-red-600 hover:underline hidden">Eliminar</button>
+                        </div>
                     </div>
-                @endforeach
-            </div>
+                    <button type="button" id="add-price" class="mt-3 text-sm text-blue-600 hover:underline">+ Agregar tipo de precio</button>
+                </div>
 
-            <div class="flex items-center">
-                <label class="mr-2 text-sm">Activo</label>
-                <input type="checkbox" name="active" value="1" checked>
-            </div>
+                <div class="flex items-center">
+                    <label class="mr-2 text-sm">Activo</label>
+                    <input type="checkbox" name="active" value="1" checked>
+                </div>
 
-
-            <div class="flex items-center gap-4">
-                <x-primary-button>Guardar</x-primary-button>
-                <x-secondary-button type="button" onclick="window.location='{{ route('services.index') }}'">Cancelar</x-secondary-button>
-            </div>
-        </form>
+                <div class="flex items-center gap-4">
+                    <x-primary-button>Guardar</x-primary-button>
+                    <x-secondary-button type="button" onclick="window.location='{{ route('services.index') }}'">Cancelar</x-secondary-button>
+                </div>
+            </form>
         </div>
     </div>
+    <template id="price-row-template">
+        <div class="price-row flex flex-wrap items-end gap-2">
+            <div class="flex-1 min-w-[200px]">
+                <label class="block text-xs text-gray-600 uppercase tracking-wide">Nombre</label>
+                <input type="text" class="form-input w-full" required>
+            </div>
+            <div class="w-40">
+                <label class="block text-xs text-gray-600 uppercase tracking-wide">Precio</label>
+                <input type="number" step="0.01" class="form-input w-full" required>
+            </div>
+            <button type="button" class="remove-price text-sm text-red-600 hover:underline">Eliminar</button>
+        </div>
+    </template>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const container = document.getElementById('price-options');
+            const addBtn = document.getElementById('add-price');
+            const template = document.getElementById('price-row-template');
+
+            const refreshIndexes = () => {
+                const rows = container.querySelectorAll('.price-row');
+                rows.forEach((row, index) => {
+                    const labelInput = row.querySelector('input[type="text"]');
+                    const priceInput = row.querySelector('input[type="number"]');
+                    labelInput.name = `price_options[${index}][label]`;
+                    priceInput.name = `price_options[${index}][price]`;
+                    row.querySelector('.remove-price').classList.toggle('hidden', rows.length === 1);
+                });
+            };
+
+            addBtn.addEventListener('click', () => {
+                const fragment = template.content.cloneNode(true);
+                container.appendChild(fragment);
+                refreshIndexes();
+            });
+
+            container.addEventListener('click', (event) => {
+                if (event.target.classList.contains('remove-price')) {
+                    const rows = container.querySelectorAll('.price-row');
+                    if (rows.length > 1) {
+                        event.target.closest('.price-row').remove();
+                        refreshIndexes();
+                    }
+                }
+            });
+
+            refreshIndexes();
+        });
+    </script>
 </x-app-layout>

--- a/resources/views/services/edit.blade.php
+++ b/resources/views/services/edit.blade.php
@@ -19,14 +19,39 @@
                 <label for="description" class="block font-medium text-sm text-gray-700">Descripción</label>
                 <textarea name="description" class="form-input w-full">{{ $service->description }}</textarea>
             </div>
+
             <div>
-                <label class="block font-medium text-sm text-gray-700 mb-1">Precios por tipo de vehículo</label>
-                @foreach ($vehicleTypes as $type)
-                    <div class="flex items-center gap-2 mb-1">
-                        <span class="w-32">{{ $type->name }}</span>
-                        <input type="number" name="prices[{{ $type->id }}]" step="0.01" value="{{ $prices[$type->id] ?? '' }}" required class="form-input w-full">
-                    </div>
-                @endforeach
+                <label class="block font-medium text-sm text-gray-700 mb-2">Tipos de precio</label>
+                <div id="price-options" class="space-y-3">
+                    @forelse ($prices as $index => $price)
+                        <div class="price-row flex flex-wrap items-end gap-2">
+                            <input type="hidden" name="price_options[{{ $index }}][id]" value="{{ $price->id }}">
+                            <div class="flex-1 min-w-[200px]">
+                                <label class="block text-xs text-gray-600 uppercase tracking-wide">Nombre</label>
+                                <input type="text" name="price_options[{{ $index }}][label]" value="{{ $price->label }}" class="form-input w-full" required>
+                            </div>
+                            <div class="w-40">
+                                <label class="block text-xs text-gray-600 uppercase tracking-wide">Precio</label>
+                                <input type="number" name="price_options[{{ $index }}][price]" step="0.01" value="{{ $price->price }}" class="form-input w-full" required>
+                            </div>
+                            <button type="button" class="remove-price text-sm text-red-600 hover:underline {{ $loop->count === 1 ? 'hidden' : '' }}">Eliminar</button>
+                        </div>
+                    @empty
+                        <div class="price-row flex flex-wrap items-end gap-2">
+                            <input type="hidden" name="price_options[0][id]" value="">
+                            <div class="flex-1 min-w-[200px]">
+                                <label class="block text-xs text-gray-600 uppercase tracking-wide">Nombre</label>
+                                <input type="text" name="price_options[0][label]" class="form-input w-full" required>
+                            </div>
+                            <div class="w-40">
+                                <label class="block text-xs text-gray-600 uppercase tracking-wide">Precio</label>
+                                <input type="number" name="price_options[0][price]" step="0.01" class="form-input w-full" required>
+                            </div>
+                            <button type="button" class="remove-price text-sm text-red-600 hover:underline hidden">Eliminar</button>
+                        </div>
+                    @endforelse
+                </div>
+                <button type="button" id="add-price" class="mt-3 text-sm text-blue-600 hover:underline">+ Agregar tipo de precio</button>
             </div>
 
             <div class="flex items-center">
@@ -42,4 +67,61 @@
             </div>
         </form>
     </div>
+    <template id="price-row-template">
+        <div class="price-row flex flex-wrap items-end gap-2">
+            <input type="hidden">
+            <div class="flex-1 min-w-[200px]">
+                <label class="block text-xs text-gray-600 uppercase tracking-wide">Nombre</label>
+                <input type="text" class="form-input w-full" required>
+            </div>
+            <div class="w-40">
+                <label class="block text-xs text-gray-600 uppercase tracking-wide">Precio</label>
+                <input type="number" step="0.01" class="form-input w-full" required>
+            </div>
+            <button type="button" class="remove-price text-sm text-red-600 hover:underline">Eliminar</button>
+        </div>
+</template>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const container = document.getElementById('price-options');
+            const addBtn = document.getElementById('add-price');
+            const template = document.getElementById('price-row-template');
+
+            const refreshIndexes = () => {
+                const rows = container.querySelectorAll('.price-row');
+                rows.forEach((row, index) => {
+                    const idInput = row.querySelector('input[type="hidden"]');
+                    const labelInput = row.querySelector('input[type="text"]');
+                    const priceInput = row.querySelector('input[type="number"]');
+
+                    idInput.name = `price_options[${index}][id]`;
+                    labelInput.name = `price_options[${index}][label]`;
+                    priceInput.name = `price_options[${index}][price]`;
+
+                    row.querySelector('.remove-price').classList.toggle('hidden', rows.length === 1);
+                });
+            };
+
+            addBtn.addEventListener('click', () => {
+                const fragment = template.content.cloneNode(true);
+                const newRow = fragment.querySelector('.price-row');
+                newRow.querySelector('input[type="hidden"]').value = '';
+                container.appendChild(fragment);
+                refreshIndexes();
+            });
+
+            container.addEventListener('click', (event) => {
+                if (event.target.classList.contains('remove-price')) {
+                    const rows = container.querySelectorAll('.price-row');
+                    if (rows.length > 1) {
+                        event.target.closest('.price-row').remove();
+                        refreshIndexes();
+                    }
+                }
+            });
+
+            refreshIndexes();
+        });
+    </script>
 </x-app-layout>

--- a/resources/views/tickets/create.blade.php
+++ b/resources/views/tickets/create.blade.php
@@ -31,51 +31,29 @@
                 <div id="wash-list" class="space-y-4 mt-4"></div>
 
                 <div id="wash-form" class="space-y-4 mt-4 hidden">
-                    <!-- Placa -->
-                    <div class="relative">
-                        <label class="block text-sm font-medium text-gray-700">Placa</label>
-                        <input type="text" name="temp_plate" id="plate" autocomplete="off" pattern="[A-Za-z0-9]+" class="form-input w-full mt-1">
-                        <ul id="plate-options" class="absolute z-10 bg-white border border-gray-300 w-full mt-1 max-h-40 overflow-auto hidden"></ul>
-                    </div>
-
-                    <!-- Marca -->
+                    <!-- Servicio -->
                     <div>
-                        <label class="block text-sm font-medium text-gray-700">Marca</label>
-                        <input type="text" name="temp_brand" pattern="[A-Za-z0-9 ]+" class="form-input w-full mt-1">
-                    </div>
-
-                    <!-- Modelo -->
-                    <div>
-                        <label class="block text-sm font-medium text-gray-700">Modelo</label>
-                        <input type="text" name="temp_model" pattern="[A-Za-z0-9 ]+" class="form-input w-full mt-1">
-                    </div>
-
-                    <!-- Color -->
-                    <div>
-                        <label class="block text-sm font-medium text-gray-700">Color</label>
-                        <input type="text" name="temp_color" pattern="[A-Za-zÁÉÍÓÚáéíóúñÑ ]+" class="form-input w-full mt-1">
-                    </div>
-
-                    <!-- Año -->
-                    <div>
-                        <label class="block text-sm font-medium text-gray-700">Año</label>
-                        <input type="number" name="temp_year" min="1890" max="{{ date('Y') }}" class="form-input w-full mt-1">
-                    </div>
-
-                    <!-- Tipo de Vehículo -->
-                    <div>
-                        <label class="block text-sm font-medium text-gray-700">Tipo de Vehículo</label>
-                        <select name="temp_vehicle_type_id" class="form-select w-full mt-1">
+                        <label class="block text-sm font-medium text-gray-700">Servicio</label>
+                        <select name="temp_service_id" class="form-select w-full mt-1" onchange="handleTempServiceChange(this)">
                             <option value="">-- Seleccionar --</option>
-                            @foreach ($vehicleTypes as $type)
-                                <option value="{{ $type->id }}" data-name="{{ $type->name }}">{{ $type->name }}</option>
+                            @foreach ($services as $service)
+                                <option value="{{ $service->id }}">{{ $service->name }}</option>
                             @endforeach
                         </select>
                     </div>
 
-                    <!-- Lavador -->
+                    <!-- Opción de precio -->
+                    <div id="price-option-wrapper" class="hidden">
+                        <label class="block text-sm font-medium text-gray-700">Opción de precio</label>
+                        <select name="temp_service_price_id" class="form-select w-full mt-1" onchange="updateTempPriceDisplay()">
+                            <option value="">-- Seleccionar --</option>
+                        </select>
+                        <p class="text-sm text-gray-600 mt-1">Precio: RD$ <span id="temp_service_price">0.00</span></p>
+                    </div>
+
+                    <!-- Estilista -->
                     <div>
-                        <label class="block text-sm font-medium text-gray-700">Lavador</label>
+                        <label class="block text-sm font-medium text-gray-700">Estilista</label>
                         <div class="flex space-x-2 mt-1">
                             <select name="temp_washer_id" class="form-select w-full" data-searchable>
                                 <option value="">-- Seleccionar --</option>
@@ -93,26 +71,14 @@
                         <input type="number" name="temp_tip" min="0" step="0.01" class="form-input w-full mt-1">
                     </div>
 
-                    <!-- Lista Servicios -->
-                    <div>
-                        <label class="block text-sm font-medium text-gray-700">Servicios Realizados</label>
-                        <div id="service-list">
-                        @foreach ($services as $service)
-                            <div class="flex items-center space-x-2 mt-1">
-                                <input type="checkbox" name="temp_service_ids[]" value="{{ $service->id }}">
-                                <label data-service-id="{{ $service->id }}" data-name="{{ $service->name }}">{{ $service->name }}</label>
-                            </div>
-                        @endforeach
-                        </div>
-                    </div>
-                <div class="mt-2 space-x-2">
-                        <button type="button" id="save-wash-btn" class="px-3 py-1 text-sm text-white bg-blue-600 rounded hover:bg-blue-700" onclick="saveWash()">Agregar lavado</button>
+                    <div class="mt-2 space-x-2">
+                        <button type="button" id="save-wash-btn" class="px-3 py-1 text-sm text-white bg-blue-600 rounded hover:bg-blue-700" onclick="saveWash()">Agregar servicio</button>
                         <button type="button" id="cancel-wash-btn" class="px-3 py-1 text-sm text-gray-700 bg-gray-200 rounded hover:bg-gray-300 hidden" onclick="cancelWashForm()">Cancelar</button>
                     </div>
                 </div>
 
                 <div class="mt-2">
-                    <button type="button" id="show-wash-form-btn" class="text-sm text-blue-600" onclick="showWashForm()">Agregar lavado</button>
+                    <button type="button" id="show-wash-form-btn" class="text-sm text-blue-600" onclick="showWashForm()">Agregar servicio</button>
                 </div>
             </details>
 
@@ -206,6 +172,9 @@
 
     <script>
         const servicePrices = @json($servicePrices);
+        const servicesCatalog = @json($services->mapWithKeys(function ($service) {
+            return [$service->id => ['name' => $service->name]];
+        }));
         const productPrices = @json($productPrices);
         const productStocks = @json($productStocks);
         const drinkPrices = @json($drinkPrices);
@@ -386,23 +355,33 @@
             const form = document.getElementById('wash-form');
             document.getElementById('show-wash-form-btn').classList.add('hidden');
             document.getElementById('cancel-wash-btn').classList.remove('hidden');
-            document.getElementById('save-wash-btn').textContent = 'Agregar lavado';
+            document.getElementById('save-wash-btn').textContent = form.dataset.editIndex ? 'Guardar cambios' : 'Agregar servicio';
             form.classList.remove('hidden');
+        }
+
+        function resetWashForm() {
+            const form = document.getElementById('wash-form');
             form.dataset.editIndex = '';
+            form.querySelector('select[name="temp_service_id"]').value = '';
+            handleTempServiceChange(form.querySelector('select[name="temp_service_id"]'));
+            const priceSelect = form.querySelector('select[name="temp_service_price_id"]');
+            priceSelect.value = '';
+            document.getElementById('temp_service_price').textContent = '0.00';
+            const washerSelect = form.querySelector('select[name="temp_washer_id"]');
+            washerSelect.value = '';
+            if (washerSelect._searchInput) {
+                washerSelect._searchInput.value = '';
+            }
+            form.querySelector('input[name="temp_tip"]').value = '';
         }
 
         function cancelWashForm() {
             const form = document.getElementById('wash-form');
-            document.getElementById('wash-list').after(form);
+            resetWashForm();
             form.classList.add('hidden');
             document.getElementById('show-wash-form-btn').classList.remove('hidden');
             document.getElementById('cancel-wash-btn').classList.add('hidden');
-            document.getElementById('save-wash-btn').textContent = 'Agregar lavado';
-            delete form.dataset.editIndex;
-            form.querySelectorAll('input[type=text], input[type=number]').forEach(el=>el.value='');
-            form.querySelectorAll('select').forEach(sel=>{sel.value=''; if(sel._searchInput) sel._searchInput.value='';});
-            form.querySelectorAll('input[type=checkbox]').forEach(cb=>cb.checked=false);
-            document.querySelectorAll('.wash-item').forEach(w=>w.removeAttribute('open'));
+            document.getElementById('save-wash-btn').textContent = 'Agregar servicio';
         }
 
         function clearWasher(){
@@ -411,105 +390,189 @@
             if(sel._searchInput) sel._searchInput.value='';
         }
 
+        function showFormError(message) {
+            const list = document.getElementById('error-list');
+            list.innerHTML = `<li>${message}</li>`;
+            window.dispatchEvent(new CustomEvent('open-modal', { detail: 'error-modal' }));
+        }
+
+        function handleTempServiceChange(select) {
+            const serviceId = select.value;
+            const wrapper = document.getElementById('price-option-wrapper');
+            const priceSelect = wrapper.querySelector('select');
+            priceSelect.innerHTML = '<option value="">-- Seleccionar --</option>';
+            priceSelect.value = '';
+            document.getElementById('temp_service_price').textContent = '0.00';
+
+            if (!serviceId) {
+                wrapper.classList.add('hidden');
+                return;
+            }
+
+            const options = servicePrices[serviceId] || [];
+            if (!options.length) {
+                wrapper.classList.add('hidden');
+                return;
+            }
+
+            wrapper.classList.remove('hidden');
+            options.forEach(opt => {
+                const option = document.createElement('option');
+                option.value = opt.id;
+                option.textContent = `${opt.label} (RD$ ${parseFloat(opt.price).toFixed(2)})`;
+                priceSelect.appendChild(option);
+            });
+
+            if (options.length === 1) {
+                priceSelect.value = options[0].id;
+                document.getElementById('temp_service_price').textContent = parseFloat(options[0].price).toFixed(2);
+            }
+
+            if (priceSelect._searchInput) {
+                priceSelect._searchInput.value = priceSelect.options[priceSelect.selectedIndex]?.text || '';
+            }
+        }
+
+        function updateTempPriceDisplay() {
+            const form = document.getElementById('wash-form');
+            const serviceId = form.querySelector('select[name="temp_service_id"]').value;
+            const priceId = form.querySelector('select[name="temp_service_price_id"]').value;
+            const options = servicePrices[serviceId] || [];
+            const selected = options.find(opt => String(opt.id) === priceId);
+            const price = selected ? parseFloat(selected.price) : 0;
+            document.getElementById('temp_service_price').textContent = price.toFixed(2);
+        }
+
+        function createHiddenInput(field, value) {
+            const input = document.createElement('input');
+            input.type = 'hidden';
+            input.dataset.field = field;
+            input.value = value;
+            return input;
+        }
+
         function saveWash() {
             const form = document.getElementById('wash-form');
-            const editing = form.dataset.editIndex !== undefined && form.dataset.editIndex !== '';
-            const index = editing ? parseInt(form.dataset.editIndex) : document.querySelectorAll('.wash-item').length;
-            const plate = form.querySelector('input[name="temp_plate"]').value.trim();
-            const brand = form.querySelector('input[name="temp_brand"]').value.trim();
-            const model = form.querySelector('input[name="temp_model"]').value.trim();
-            const color = form.querySelector('input[name="temp_color"]').value.trim();
-            const year = form.querySelector('input[name="temp_year"]').value.trim();
-            const vtSelect = form.querySelector('select[name="temp_vehicle_type_id"]');
-            const vehicleTypeId = vtSelect.value;
-            const vehicleTypeName = vtSelect.options[vtSelect.selectedIndex]?.dataset.name || '';
+            const serviceSelect = form.querySelector('select[name="temp_service_id"]');
+            const serviceId = serviceSelect.value;
+            if (!serviceId) {
+                showFormError('Debe seleccionar un servicio.');
+                return;
+            }
+
+            const options = servicePrices[serviceId] || [];
+            if (!options.length) {
+                showFormError('El servicio seleccionado no tiene opciones de precio configuradas.');
+                return;
+            }
+            let priceOptionId = form.querySelector('select[name="temp_service_price_id"]').value;
+            if (options.length === 1) {
+                priceOptionId = options[0].id;
+            }
+            const priceOption = options.find(opt => String(opt.id) === String(priceOptionId));
+            if (options.length > 1 && !priceOption) {
+                showFormError('Seleccione una opción de precio.');
+                return;
+            }
+
             const washerSelect = form.querySelector('select[name="temp_washer_id"]');
             const washerId = washerSelect.value;
-            const washerName = washerId ? washerSelect.options[washerSelect.selectedIndex].text : '';
-            const services = Array.from(form.querySelectorAll('input[name="temp_service_ids[]"]:checked')).map(cb => ({id: cb.value, name: cb.nextElementSibling.dataset.name}));
-            if (services.length === 0) { return; }
-
-            let washTotal = 0, washDiscount = 0;
-            services.forEach(s => {
-                let price = servicePrices[s.id] && servicePrices[s.id][vehicleTypeId] ? parseFloat(servicePrices[s.id][vehicleTypeId]) : 0;
-                const disc = serviceDiscounts[s.id];
-                if (disc) {
-                    const d = disc.type === 'fixed' ? parseFloat(disc.amount) : price * parseFloat(disc.amount) / 100;
-                    washDiscount += d;
-                    price = Math.max(0, price - d);
-                }
-                washTotal += price;
-            });
+            const washerName = washerId ? washerSelect.options[washerSelect.selectedIndex]?.text : '';
             const tip = parseFloat(form.querySelector('input[name="temp_tip"]').value) || 0;
-            washTotal += tip;
 
-            const summary = `${brand} | ${model} | ${color} | ${year} | ${vehicleTypeName}`;
+            const basePrice = priceOption ? parseFloat(priceOption.price) : 0;
+            const discountInfo = serviceDiscounts[serviceId];
+            let discount = 0;
+            let finalPrice = basePrice;
+            if (discountInfo) {
+                const amount = parseFloat(discountInfo.amount);
+                discount = discountInfo.type === 'fixed' ? amount : (basePrice * amount / 100);
+                finalPrice = Math.max(0, basePrice - discount);
+            }
+
+            const total = finalPrice + tip;
+            const serviceName = servicesCatalog[serviceId]?.name || serviceSelect.options[serviceSelect.selectedIndex]?.text || '';
+            const priceLabel = priceOption ? priceOption.label : '';
+
+            const editing = form.dataset.editIndex !== undefined && form.dataset.editIndex !== '';
+            const index = editing ? parseInt(form.dataset.editIndex, 10) : document.querySelectorAll('#wash-list .wash-item').length;
+
             let wrapper;
             if (editing) {
-                wrapper = document.querySelectorAll('.wash-item')[index];
+                wrapper = document.querySelectorAll('#wash-list .wash-item')[index];
                 wrapper.innerHTML = '';
             } else {
-                wrapper = document.createElement('details');
-                wrapper.className = 'border rounded p-2 wash-item';
-                wrapper.addEventListener('toggle', function(){ if(this.open) editWash(this); else cancelWashForm(); });
+                wrapper = document.createElement('div');
+                wrapper.className = 'border rounded p-3 wash-item';
                 document.getElementById('wash-list').appendChild(wrapper);
             }
-            wrapper.dataset.total = washTotal;
-            wrapper.dataset.discount = washDiscount;
-            const servicesText = services.map(s=>s.name).join(', ');
-            wrapper.innerHTML = `<summary class="cursor-pointer font-medium text-gray-700">${summary}<button type="button" class="ml-2 text-red-600" onclick="removeWash(this); event.stopPropagation();">Eliminar</button></summary>` +
-                services.map(s=>`<input type="hidden" name="washes[${index}][service_ids][]" value="${s.id}">`).join('') +
-                `<input type="hidden" name="washes[${index}][plate]" value="${plate}">` +
-                `<input type="hidden" name="washes[${index}][brand]" value="${brand}">` +
-                `<input type="hidden" name="washes[${index}][model]" value="${model}">` +
-                `<input type="hidden" name="washes[${index}][color]" value="${color}">` +
-                `<input type="hidden" name="washes[${index}][year]" value="${year}">` +
-                `<input type="hidden" name="washes[${index}][vehicle_type_id]" value="${vehicleTypeId}">` +
-                `<input type="hidden" name="washes[${index}][washer_id]" value="${washerId}">` +
-                `<input type="hidden" name="washes[${index}][tip]" value="${tip.toFixed(2)}">` +
-                `<div class="mt-2 space-y-1 text-sm"><p>Placa: ${plate}</p><p>Lavador: ${washerName || 'N/A'}</p><p>Servicios: ${servicesText}</p><p>Propina: RD$ ${tip.toFixed(2)}</p></div>`;
+
+            wrapper.dataset.total = total;
+            wrapper.dataset.discount = discount;
+            wrapper.dataset.serviceId = serviceId;
+            wrapper.dataset.priceLabel = priceLabel || '';
+
+            const info = document.createElement('div');
+            info.className = 'flex justify-between items-start gap-4';
+            info.innerHTML = `
+                <div>
+                    <p class="font-semibold text-gray-800">${serviceName}</p>
+                    ${priceLabel ? `<p class="text-sm text-gray-600">${priceLabel}</p>` : ''}
+                    ${washerName ? `<p class="text-sm text-gray-600">Estilista: ${washerName}</p>` : ''}
+                    ${tip > 0 ? `<p class="text-sm text-gray-600">Propina: RD$ ${tip.toFixed(2)}</p>` : ''}
+                    <p class="text-sm font-medium text-gray-800">Subtotal: RD$ ${total.toFixed(2)}</p>
+                </div>
+                <div class="flex gap-2 text-sm">
+                    <button type="button" class="text-blue-600 hover:underline" onclick="editWash(this)">Editar</button>
+                    <button type="button" class="text-red-600 hover:underline" onclick="removeWash(this)">Eliminar</button>
+                </div>
+            `;
+            wrapper.appendChild(info);
+
+            const hiddenFields = [
+                createHiddenInput('service_id', serviceId),
+                createHiddenInput('service_price_id', priceOption ? priceOption.id : ''),
+                createHiddenInput('washer_id', washerId || ''),
+                createHiddenInput('tip', tip.toFixed(2))
+            ];
+            hiddenFields.forEach(input => wrapper.appendChild(input));
 
             updateWashIndexes();
-
-            form.querySelectorAll('input[type=text], input[type=number]').forEach(el=>el.value='');
-            form.querySelectorAll('select').forEach(sel=>{sel.value=''; if(sel._searchInput) sel._searchInput.value='';});
-            form.querySelectorAll('input[type=checkbox]').forEach(cb=>cb.checked=false);
-            form.querySelector('input[name="temp_tip"]').value='';
-            delete form.dataset.editIndex;
-            document.getElementById('wash-list').after(form);
-            form.classList.add('hidden');
-            document.getElementById('show-wash-form-btn').classList.remove('hidden');
-            document.getElementById('cancel-wash-btn').classList.add('hidden');
-            document.getElementById('save-wash-btn').textContent = 'Agregar lavado';
-            wrapper.removeAttribute('open');
+            resetWashForm();
+            cancelWashForm();
             updateTotal();
         }
 
-        function editWash(wrapper) {
-            const index = Array.from(document.querySelectorAll('.wash-item')).indexOf(wrapper);
+        function editWash(btn) {
+            const wrapper = btn.closest('.wash-item');
+            const index = Array.from(document.querySelectorAll('#wash-list .wash-item')).indexOf(wrapper);
             const form = document.getElementById('wash-form');
             form.dataset.editIndex = index;
-            document.getElementById('show-wash-form-btn').classList.add('hidden');
-            document.getElementById('cancel-wash-btn').classList.add('hidden');
             document.getElementById('save-wash-btn').textContent = 'Guardar cambios';
-            form.classList.remove('hidden');
-            wrapper.appendChild(form);
-            form.querySelector('input[name="temp_plate"]').value = wrapper.querySelector(`input[name="washes[${index}][plate]"]`).value;
-            form.querySelector('input[name="temp_brand"]').value = wrapper.querySelector(`input[name="washes[${index}][brand]"]`).value;
-            form.querySelector('input[name="temp_model"]').value = wrapper.querySelector(`input[name="washes[${index}][model]"]`).value;
-            form.querySelector('input[name="temp_color"]').value = wrapper.querySelector(`input[name="washes[${index}][color]"]`).value;
-            form.querySelector('input[name="temp_year"]').value = wrapper.querySelector(`input[name="washes[${index}][year]"]`).value;
-            form.querySelector('select[name="temp_vehicle_type_id"]').value = wrapper.querySelector(`input[name="washes[${index}][vehicle_type_id]"]`).value;
-            const washerSelect = form.querySelector('select[name="temp_washer_id"]');
-            washerSelect.value = wrapper.querySelector(`input[name="washes[${index}][washer_id]"]`).value;
-            if(washerSelect._searchInput){ washerSelect._searchInput.value = washerSelect.options[washerSelect.selectedIndex]?.text || ''; }
-            form.querySelector('input[name="temp_tip"]').value = wrapper.querySelector(`input[name="washes[${index}][tip]"]`).value;
-            form.querySelectorAll('input[name="temp_service_ids[]"]').forEach(cb=>{
-                const val = cb.value;
-                cb.checked = wrapper.querySelector(`input[name="washes[${index}][service_ids][]"][value="${val}"]`) !== null;
-            });
 
-            document.querySelectorAll('.wash-item').forEach(w=>{ if(w!==wrapper) w.removeAttribute('open'); });
+            const serviceId = wrapper.querySelector('input[data-field="service_id"]').value;
+            const priceId = wrapper.querySelector('input[data-field="service_price_id"]').value;
+            const washerId = wrapper.querySelector('input[data-field="washer_id"]').value;
+            const tip = wrapper.querySelector('input[data-field="tip"]').value;
+
+            const serviceSelect = form.querySelector('select[name="temp_service_id"]');
+            serviceSelect.value = serviceId;
+            handleTempServiceChange(serviceSelect);
+
+            const priceSelect = form.querySelector('select[name="temp_service_price_id"]');
+            if (priceId) {
+                priceSelect.value = priceId;
+                updateTempPriceDisplay();
+            }
+
+            const washerSelect = form.querySelector('select[name="temp_washer_id"]');
+            washerSelect.value = washerId;
+            if (washerSelect._searchInput) {
+                washerSelect._searchInput.value = washerSelect.options[washerSelect.selectedIndex]?.text || '';
+            }
+            form.querySelector('input[name="temp_tip"]').value = tip;
+
+            showWashForm();
         }
 
         function removeWash(btn) {
@@ -521,13 +584,9 @@
 
         function updateWashIndexes(){
             document.querySelectorAll('#wash-list .wash-item').forEach((item,i)=>{
-                item.querySelectorAll('input[name^="washes["]').forEach(input=>{
-                    const field = input.name.replace(/washes\[\d+\]\[(.*)\]/,'$1');
-                    if(field.startsWith('service_ids')){
-                        input.name = `washes[${i}][service_ids][]`;
-                    }else{
-                        input.name = `washes[${i}][${field}]`;
-                    }
+                item.dataset.index = i;
+                item.querySelectorAll('input[data-field]').forEach(input=>{
+                    input.name = `washes[${i}][${input.dataset.field}]`;
                 });
             });
         }
@@ -538,14 +597,8 @@
             field.style.display = method === 'transferencia' ? '' : 'none';
         }
 
-        const plateInput = document.getElementById('plate');
         const nameInput = document.querySelector('input[name="customer_name"]');
         const phoneInput = document.querySelector('input[name="customer_phone"]');
-        const colorInput = document.querySelector('input[name="temp_color"]');
-        const yearInput = document.querySelector('input[name="temp_year"]');
-        const plateList = document.getElementById('plate-options');
-        let plateData = [];
-        let selectedIndex = -1;
 
         function restrictInput(el, keyRegex, pasteRegex, msg){
             el.addEventListener('keydown', e => {
@@ -569,9 +622,6 @@
         }
 
         restrictInput(nameInput, /^[A-Za-zÁÉÍÓÚáéíóúñÑ ]$/, /^[A-Za-zÁÉÍÓÚáéíóúñÑ ]+$/, 'El nombre solo puede contener letras');
-        restrictInput(plateInput, /^[A-Za-z0-9]$/, /^[A-Za-z0-9]+$/, 'La placa solo puede contener letras y números');
-        restrictInput(colorInput, /^[A-Za-zÁÉÍÓÚáéíóúñÑ ]$/, /^[A-Za-zÁÉÍÓÚáéíóúñÑ ]+$/, 'El color solo puede contener letras');
-        restrictInput(yearInput, /^\d$/, /^\d+$/, 'El año solo puede contener números');
         restrictInput(phoneInput, /^[0-9+() -]$/, /^[0-9+() -]+$/, 'El teléfono solo puede contener números');
 
         function convertSelectToSearchable(select){
@@ -596,102 +646,6 @@
             list.addEventListener('mousedown', e=>{const li=e.target.closest('li'); if(!li) return; e.preventDefault(); input.value=li.textContent; select.value=li.dataset.val; select.dispatchEvent(new Event('change')); list.classList.add('hidden');});
             input.addEventListener('blur', ()=>setTimeout(()=>list.classList.add('hidden'),200));
         }
-
-        const maxYear = {{ date('Y') }};
-        const minYear = 1890;
-        yearInput.addEventListener('input', () => {
-            let val = yearInput.value.replace(/\D/g, '').slice(0, 4);
-            yearInput.value = val;
-            if (val.length === 4) {
-                const num = parseInt(val, 10);
-                if (num < minYear || num > maxYear) {
-                    yearInput.value = '';
-                    const list = document.getElementById('error-list');
-                    list.innerHTML = `<li>El año debe estar entre ${minYear} y ${maxYear}</li>`;
-                    window.dispatchEvent(new CustomEvent('open-modal', { detail: 'error-modal' }));
-                }
-            }
-        });
-
-        plateInput.addEventListener('input', async () => {
-            const q = plateInput.value.trim();
-            if (!q) { plateList.innerHTML = ''; plateList.classList.add('hidden'); return; }
-            try {
-                const res = await fetch(`{{ route('vehicles.search') }}?plate=${encodeURIComponent(q)}`, {headers:{'Accept':'application/json'}});
-                if(res.ok){
-                    plateData = (await res.json()).slice(0,10);
-                    plateList.innerHTML = '';
-                    selectedIndex = -1;
-                    if(plateData.length === 0){
-                        plateList.classList.add('hidden');
-                        return;
-                    }
-                    plateList.classList.remove('hidden');
-                    plateData.forEach(v => {
-                        const li = document.createElement('li');
-                        li.textContent = `${v.brand} | ${v.model} | ${v.color} | ${v.year ?? ''} | ${v.plate} | ${v.type}`;
-                        li.dataset.plate = v.plate;
-                        li.className = 'px-2 py-1 cursor-pointer hover:bg-gray-200';
-                        plateList.appendChild(li);
-                    });
-                }
-            } catch(e) {}
-        });
-
-        plateInput.addEventListener('keydown', e => {
-            const items = plateList.querySelectorAll('li');
-            if(plateList.classList.contains('hidden') || items.length === 0) return;
-            if(e.key === 'ArrowDown'){
-                e.preventDefault();
-                selectedIndex = (selectedIndex + 1) % items.length;
-                updateActive(items);
-            } else if(e.key === 'ArrowUp'){
-                e.preventDefault();
-                selectedIndex = (selectedIndex - 1 + items.length) % items.length;
-                updateActive(items);
-            } else if(e.key === 'Enter' && selectedIndex >= 0){
-                e.preventDefault();
-                const li = items[selectedIndex];
-                plateInput.value = li.dataset.plate;
-                fillVehicleFields(li.dataset.plate);
-                plateList.classList.add('hidden');
-            }
-        });
-
-        function updateActive(items){
-            items.forEach((li,i)=>{
-                li.classList.toggle('bg-gray-200', i===selectedIndex);
-            });
-        }
-
-        plateList.addEventListener('mousedown', e => {
-            const li = e.target.closest('li[data-plate]');
-            if(!li) return;
-            e.preventDefault();
-            plateInput.value = li.dataset.plate;
-            fillVehicleFields(li.dataset.plate);
-            plateList.classList.add('hidden');
-        });
-
-        plateInput.addEventListener('blur', () => {
-            setTimeout(() => plateList.classList.add('hidden'), 200);
-        });
-
-        plateInput.addEventListener('change', () => {
-            fillVehicleFields(plateInput.value);
-        });
-
-        function fillVehicleFields(plate){
-            const found = plateData.find(v => v.plate === plate);
-            if(found){
-                document.querySelector('input[name="temp_brand"]').value = found.brand;
-                document.querySelector('input[name="temp_model"]').value = found.model;
-                document.querySelector('input[name="temp_color"]').value = found.color;
-                document.querySelector('input[name="temp_year"]').value = found.year || '';
-                document.querySelector('select[name="temp_vehicle_type_id"]').value = found.vehicle_type_id;
-            }
-        }
-
 
         document.querySelectorAll('select[data-searchable]').forEach(convertSelectToSearchable);
 

--- a/resources/views/tickets/edit.blade.php
+++ b/resources/views/tickets/edit.blade.php
@@ -31,82 +31,56 @@
                 <summary class="cursor-pointer font-medium text-gray-700">Servicios</summary>
                 <div id="wash-list" class="space-y-4 mt-4">
                     @foreach($ticketWashes as $i => $wData)
-                        @php
-                            $w = $wData['wash'];
-                            $summary = $w->vehicle->brand.' | '.$w->vehicle->model.' | '.$w->vehicle->color.' | '.$w->vehicle->year.' | '.$w->vehicleType->name;
-                            $servicesText = $w->details->where('type','service')->map(fn($d)=>$d->service->name)->implode(', ');
-                        @endphp
-                        <details class="border rounded p-2 wash-item" data-total="{{ $wData['total'] }}" data-discount="{{ $wData['discount'] }}" ontoggle="if(this.open) editWash(this); else cancelWashForm();">
-                            <summary class="cursor-pointer font-medium text-gray-700">{{ $summary }}<button type="button" class="ml-2 text-red-600" onclick="removeWash(this); event.stopPropagation();">Eliminar</button></summary>
-                            @foreach($wData['service_ids'] as $sid)
-                                <input type="hidden" name="washes[{{ $i }}][service_ids][]" value="{{ $sid }}">
-                            @endforeach
-                            <input type="hidden" name="washes[{{ $i }}][plate]" value="{{ $w->vehicle->plate }}">
-                            <input type="hidden" name="washes[{{ $i }}][brand]" value="{{ $w->vehicle->brand }}">
-                            <input type="hidden" name="washes[{{ $i }}][model]" value="{{ $w->vehicle->model }}">
-                            <input type="hidden" name="washes[{{ $i }}][color]" value="{{ $w->vehicle->color }}">
-                            <input type="hidden" name="washes[{{ $i }}][year]" value="{{ $w->vehicle->year }}">
-                            <input type="hidden" name="washes[{{ $i }}][vehicle_type_id]" value="{{ $w->vehicle_type_id }}">
-                            <input type="hidden" name="washes[{{ $i }}][washer_id]" value="{{ $w->washer_id }}">
-                            <input type="hidden" name="washes[{{ $i }}][tip]" value="{{ $wData['tip'] }}">
-                            <div class="mt-2 space-y-1 text-sm">
-                                <p>Placa: {{ $w->vehicle->plate }}</p>
-                                <p>Lavador: {{ optional($w->washer)->name ?? 'N/A' }}</p>
-                                <p>Servicios: {{ $servicesText }}</p>
-                                @if($w->tip > 0)
-                                    <p>Propina: RD$ {{ number_format($w->tip,2) }}</p>
-                                @endif
+                        <div class="border rounded p-3 wash-item" data-total="{{ $wData['total'] }}" data-discount="{{ $wData['discount'] ?? 0 }}">
+                            <div class="flex justify-between items-start gap-4">
+                                <div>
+                                    <p class="font-semibold text-gray-800">{{ $wData['service_name'] }}</p>
+                                    @if(!empty($wData['price_label']))
+                                        <p class="text-sm text-gray-600">{{ $wData['price_label'] }}</p>
+                                    @endif
+                                    <p class="text-sm text-gray-600">Estilista: {{ optional($wData['wash']->washer)->name ?? 'N/A' }}</p>
+                                    @if(($wData['tip'] ?? 0) > 0)
+                                        <p class="text-sm text-gray-600">Propina: RD$ {{ number_format($wData['tip'], 2) }}</p>
+                                    @endif
+                                    <p class="text-sm font-medium text-gray-800">Subtotal: RD$ {{ number_format($wData['total'], 2) }}</p>
+                                </div>
+                                <div class="flex gap-2 text-sm">
+                                    <button type="button" class="text-blue-600 hover:underline" onclick="editWash(this)">Editar</button>
+                                    <button type="button" class="text-red-600 hover:underline" onclick="removeWash(this)">Eliminar</button>
+                                </div>
                             </div>
-                        </details>
+                            <input type="hidden" data-field="service_id" name="washes[{{ $i }}][service_id]" value="{{ $wData['service_id'] }}">
+                            <input type="hidden" data-field="service_price_id" name="washes[{{ $i }}][service_price_id]" value="{{ $wData['service_price_id'] }}">
+                            <input type="hidden" data-field="washer_id" name="washes[{{ $i }}][washer_id]" value="{{ $wData['wash']->washer_id }}">
+                            <input type="hidden" data-field="tip" name="washes[{{ $i }}][tip]" value="{{ number_format($wData['tip'], 2, '.', '') }}">
+                        </div>
                     @endforeach
                 </div>
 
                 <div id="wash-form" class="space-y-4 mt-4 hidden">
-                    <!-- Placa -->
-                    <div class="relative">
-                        <label class="block text-sm font-medium text-gray-700">Placa</label>
-                        <input type="text" name="temp_plate" id="plate" autocomplete="off" pattern="[A-Za-z0-9]+" class="form-input w-full mt-1">
-                        <ul id="plate-options" class="absolute z-10 bg-white border border-gray-300 w-full mt-1 max-h-40 overflow-auto hidden"></ul>
-                    </div>
-
-                    <!-- Marca -->
+                    <!-- Servicio -->
                     <div>
-                        <label class="block text-sm font-medium text-gray-700">Marca</label>
-                        <input type="text" name="temp_brand" pattern="[A-Za-z0-9 ]+" class="form-input w-full mt-1">
-                    </div>
-
-                    <!-- Modelo -->
-                    <div>
-                        <label class="block text-sm font-medium text-gray-700">Modelo</label>
-                        <input type="text" name="temp_model" pattern="[A-Za-z0-9 ]+" class="form-input w-full mt-1">
-                    </div>
-
-                    <!-- Color -->
-                    <div>
-                        <label class="block text-sm font-medium text-gray-700">Color</label>
-                        <input type="text" name="temp_color" pattern="[A-Za-zÁÉÍÓÚáéíóúñÑ ]+" class="form-input w-full mt-1">
-                    </div>
-
-                    <!-- Año -->
-                    <div>
-                        <label class="block text-sm font-medium text-gray-700">Año</label>
-                        <input type="number" name="temp_year" min="1890" max="{{ date('Y') }}" class="form-input w-full mt-1">
-                    </div>
-
-                    <!-- Tipo de Vehículo -->
-                    <div>
-                        <label class="block text-sm font-medium text-gray-700">Tipo de Vehículo</label>
-                        <select name="temp_vehicle_type_id" class="form-select w-full mt-1">
+                        <label class="block text-sm font-medium text-gray-700">Servicio</label>
+                        <select name="temp_service_id" class="form-select w-full mt-1" onchange="handleTempServiceChange(this)">
                             <option value="">-- Seleccionar --</option>
-                            @foreach ($vehicleTypes as $type)
-                                <option value="{{ $type->id }}" data-name="{{ $type->name }}">{{ $type->name }}</option>
+                            @foreach ($services as $service)
+                                <option value="{{ $service->id }}">{{ $service->name }}</option>
                             @endforeach
                         </select>
                     </div>
 
-                    <!-- Lavador -->
+                    <!-- Opción de precio -->
+                    <div id="price-option-wrapper" class="hidden">
+                        <label class="block text-sm font-medium text-gray-700">Opción de precio</label>
+                        <select name="temp_service_price_id" class="form-select w-full mt-1" onchange="updateTempPriceDisplay()">
+                            <option value="">-- Seleccionar --</option>
+                        </select>
+                        <p class="text-sm text-gray-600 mt-1">Precio: RD$ <span id="temp_service_price">0.00</span></p>
+                    </div>
+
+                    <!-- Estilista -->
                     <div>
-                        <label class="block text-sm font-medium text-gray-700">Lavador</label>
+                        <label class="block text-sm font-medium text-gray-700">Estilista</label>
                         <div class="flex space-x-2 mt-1">
                             <select name="temp_washer_id" class="form-select w-full" data-searchable>
                                 <option value="">-- Seleccionar --</option>
@@ -123,27 +97,14 @@
                         <label class="block text-sm font-medium text-gray-700">Propina</label>
                         <input type="number" name="temp_tip" min="0" step="0.01" class="form-input w-full mt-1">
                     </div>
-
-                    <!-- Lista Servicios -->
-                    <div>
-                        <label class="block text-sm font-medium text-gray-700">Servicios Realizados</label>
-                        <div id="service-list">
-                        @foreach ($services as $service)
-                            <div class="flex items-center space-x-2 mt-1">
-                                <input type="checkbox" name="temp_service_ids[]" value="{{ $service->id }}">
-                                <label data-service-id="{{ $service->id }}" data-name="{{ $service->name }}">{{ $service->name }}</label>
-                            </div>
-                        @endforeach
-                        </div>
-                    </div>
                     <div class="mt-2 space-x-2">
-                        <button type="button" id="save-wash-btn" class="px-3 py-1 text-sm text-white bg-blue-600 rounded hover:bg-blue-700" onclick="saveWash()">Agregar lavado</button>
+                        <button type="button" id="save-wash-btn" class="px-3 py-1 text-sm text-white bg-blue-600 rounded hover:bg-blue-700" onclick="saveWash()">Agregar servicio</button>
                         <button type="button" id="cancel-wash-btn" class="px-3 py-1 text-sm text-gray-700 bg-gray-200 rounded hover:bg-gray-300 hidden" onclick="cancelWashForm()">Cancelar</button>
                     </div>
                 </div>
 
                 <div class="mt-2">
-                    <button type="button" id="show-wash-form-btn" class="text-sm text-blue-600" onclick="showWashForm()">Agregar lavado</button>
+                    <button type="button" id="show-wash-form-btn" class="text-sm text-blue-600" onclick="showWashForm()">Agregar servicio</button>
                 </div>
             </details>
 
@@ -283,6 +244,9 @@
 
     <script>
         const servicePrices = @json($servicePrices);
+        const servicesCatalog = @json($services->mapWithKeys(function ($service) {
+            return [$service->id => ['name' => $service->name]];
+        }));
         const productPrices = @json($productPrices);
         const productStocks = @json($productStocks);
         const drinkPrices = @json($drinkPrices);
@@ -463,23 +427,33 @@
             const form = document.getElementById('wash-form');
             document.getElementById('show-wash-form-btn').classList.add('hidden');
             document.getElementById('cancel-wash-btn').classList.remove('hidden');
-            document.getElementById('save-wash-btn').textContent = 'Agregar lavado';
+            document.getElementById('save-wash-btn').textContent = form.dataset.editIndex ? 'Guardar cambios' : 'Agregar servicio';
             form.classList.remove('hidden');
+        }
+
+        function resetWashForm() {
+            const form = document.getElementById('wash-form');
             form.dataset.editIndex = '';
+            form.querySelector('select[name="temp_service_id"]').value = '';
+            handleTempServiceChange(form.querySelector('select[name="temp_service_id"]'));
+            const priceSelect = form.querySelector('select[name="temp_service_price_id"]');
+            priceSelect.value = '';
+            document.getElementById('temp_service_price').textContent = '0.00';
+            const washerSelect = form.querySelector('select[name="temp_washer_id"]');
+            washerSelect.value = '';
+            if (washerSelect._searchInput) {
+                washerSelect._searchInput.value = '';
+            }
+            form.querySelector('input[name="temp_tip"]').value = '';
         }
 
         function cancelWashForm() {
             const form = document.getElementById('wash-form');
-            document.getElementById('wash-list').after(form);
+            resetWashForm();
             form.classList.add('hidden');
             document.getElementById('show-wash-form-btn').classList.remove('hidden');
             document.getElementById('cancel-wash-btn').classList.add('hidden');
-            document.getElementById('save-wash-btn').textContent = 'Agregar lavado';
-            delete form.dataset.editIndex;
-            form.querySelectorAll('input[type=text], input[type=number]').forEach(el=>el.value='');
-            form.querySelectorAll('select').forEach(sel=>{sel.value=''; if(sel._searchInput) sel._searchInput.value='';});
-            form.querySelectorAll('input[type=checkbox]').forEach(cb=>cb.checked=false);
-            document.querySelectorAll('.wash-item').forEach(w=>w.removeAttribute('open'));
+            document.getElementById('save-wash-btn').textContent = 'Agregar servicio';
         }
 
         function clearWasher(){
@@ -488,104 +462,189 @@
             if(sel._searchInput) sel._searchInput.value='';
         }
 
+        function showFormError(message) {
+            const list = document.getElementById('error-list');
+            list.innerHTML = `<li>${message}</li>`;
+            window.dispatchEvent(new CustomEvent('open-modal', { detail: 'error-modal' }));
+        }
+
+        function handleTempServiceChange(select) {
+            const serviceId = select.value;
+            const wrapper = document.getElementById('price-option-wrapper');
+            const priceSelect = wrapper.querySelector('select');
+            priceSelect.innerHTML = '<option value="">-- Seleccionar --</option>';
+            priceSelect.value = '';
+            document.getElementById('temp_service_price').textContent = '0.00';
+
+            if (!serviceId) {
+                wrapper.classList.add('hidden');
+                return;
+            }
+
+            const options = servicePrices[serviceId] || [];
+            if (!options.length) {
+                wrapper.classList.add('hidden');
+                return;
+            }
+
+            wrapper.classList.remove('hidden');
+            options.forEach(opt => {
+                const option = document.createElement('option');
+                option.value = opt.id;
+                option.textContent = `${opt.label} (RD$ ${parseFloat(opt.price).toFixed(2)})`;
+                priceSelect.appendChild(option);
+            });
+
+            if (options.length === 1) {
+                priceSelect.value = options[0].id;
+                document.getElementById('temp_service_price').textContent = parseFloat(options[0].price).toFixed(2);
+            }
+
+            if (priceSelect._searchInput) {
+                priceSelect._searchInput.value = priceSelect.options[priceSelect.selectedIndex]?.text || '';
+            }
+        }
+
+        function updateTempPriceDisplay() {
+            const form = document.getElementById('wash-form');
+            const serviceId = form.querySelector('select[name="temp_service_id"]').value;
+            const priceId = form.querySelector('select[name="temp_service_price_id"]').value;
+            const options = servicePrices[serviceId] || [];
+            const selected = options.find(opt => String(opt.id) === priceId);
+            const price = selected ? parseFloat(selected.price) : 0;
+            document.getElementById('temp_service_price').textContent = price.toFixed(2);
+        }
+
+        function createHiddenInput(field, value) {
+            const input = document.createElement('input');
+            input.type = 'hidden';
+            input.dataset.field = field;
+            input.value = value;
+            return input;
+        }
+
         function saveWash() {
             const form = document.getElementById('wash-form');
-            const editing = form.dataset.editIndex !== undefined && form.dataset.editIndex !== '';
-            const index = editing ? parseInt(form.dataset.editIndex) : document.querySelectorAll('.wash-item').length;
-            const plate = form.querySelector('input[name="temp_plate"]').value.trim();
-            const brand = form.querySelector('input[name="temp_brand"]').value.trim();
-            const model = form.querySelector('input[name="temp_model"]').value.trim();
-            const color = form.querySelector('input[name="temp_color"]').value.trim();
-            const year = form.querySelector('input[name="temp_year"]').value.trim();
-            const vtSelect = form.querySelector('select[name="temp_vehicle_type_id"]');
-            const vehicleTypeId = vtSelect.value;
-            const vehicleTypeName = vtSelect.options[vtSelect.selectedIndex]?.dataset.name || '';
+            const serviceSelect = form.querySelector('select[name="temp_service_id"]');
+            const serviceId = serviceSelect.value;
+            if (!serviceId) {
+                showFormError('Debe seleccionar un servicio.');
+                return;
+            }
+
+            const options = servicePrices[serviceId] || [];
+            if (!options.length) {
+                showFormError('El servicio seleccionado no tiene opciones de precio configuradas.');
+                return;
+            }
+            let priceOptionId = form.querySelector('select[name="temp_service_price_id"]').value;
+            if (options.length === 1) {
+                priceOptionId = options[0].id;
+            }
+            const priceOption = options.find(opt => String(opt.id) === String(priceOptionId));
+            if (options.length > 1 && !priceOption) {
+                showFormError('Seleccione una opción de precio.');
+                return;
+            }
+
             const washerSelect = form.querySelector('select[name="temp_washer_id"]');
             const washerId = washerSelect.value;
-            const washerName = washerId ? washerSelect.options[washerSelect.selectedIndex].text : '';
-            const services = Array.from(form.querySelectorAll('input[name="temp_service_ids[]"]:checked')).map(cb => ({id: cb.value, name: cb.nextElementSibling.dataset.name}));
-            if (services.length === 0) { return; }
-
-            let washTotal = 0, washDiscount = 0;
-            services.forEach(s => {
-                let price = servicePrices[s.id] && servicePrices[s.id][vehicleTypeId] ? parseFloat(servicePrices[s.id][vehicleTypeId]) : 0;
-                const disc = serviceDiscounts[s.id];
-                if (disc) {
-                    const d = disc.type === 'fixed' ? parseFloat(disc.amount) : price * parseFloat(disc.amount) / 100;
-                    washDiscount += d;
-                    price = Math.max(0, price - d);
-                }
-                washTotal += price;
-            });
+            const washerName = washerId ? washerSelect.options[washerSelect.selectedIndex]?.text : '';
             const tip = parseFloat(form.querySelector('input[name="temp_tip"]').value) || 0;
-            washTotal += tip;
 
-            const summary = `${brand} | ${model} | ${color} | ${year} | ${vehicleTypeName}`;
+            const basePrice = priceOption ? parseFloat(priceOption.price) : 0;
+            const discountInfo = serviceDiscounts[serviceId];
+            let discount = 0;
+            let finalPrice = basePrice;
+            if (discountInfo) {
+                const amount = parseFloat(discountInfo.amount);
+                discount = discountInfo.type === 'fixed' ? amount : (basePrice * amount / 100);
+                finalPrice = Math.max(0, basePrice - discount);
+            }
+
+            const total = finalPrice + tip;
+            const serviceName = servicesCatalog[serviceId]?.name || serviceSelect.options[serviceSelect.selectedIndex]?.text || '';
+            const priceLabel = priceOption ? priceOption.label : '';
+
+            const editing = form.dataset.editIndex !== undefined && form.dataset.editIndex !== '';
+            const index = editing ? parseInt(form.dataset.editIndex, 10) : document.querySelectorAll('#wash-list .wash-item').length;
+
             let wrapper;
             if (editing) {
-                wrapper = document.querySelectorAll('.wash-item')[index];
+                wrapper = document.querySelectorAll('#wash-list .wash-item')[index];
                 wrapper.innerHTML = '';
             } else {
-                wrapper = document.createElement('details');
-                wrapper.className = 'border rounded p-2 wash-item';
-                wrapper.addEventListener('toggle', function(){ if(this.open) editWash(this); else cancelWashForm(); });
+                wrapper = document.createElement('div');
+                wrapper.className = 'border rounded p-3 wash-item';
                 document.getElementById('wash-list').appendChild(wrapper);
             }
-            wrapper.dataset.total = washTotal;
-            wrapper.dataset.discount = washDiscount;
-            const servicesText = services.map(s=>s.name).join(', ');
-            wrapper.innerHTML = `<summary class=\"cursor-pointer font-medium text-gray-700\">${summary}<button type=\"button\" class=\"ml-2 text-red-600\" onclick=\"removeWash(this); event.stopPropagation();\">Eliminar</button></summary>` +
-                services.map(s=>`<input type=\"hidden\" name=\"washes[${index}][service_ids][]\" value=\"${s.id}\">`).join('') +
-                `<input type=\"hidden\" name=\"washes[${index}][plate]\" value=\"${plate}\">` +
-                `<input type=\"hidden\" name=\"washes[${index}][brand]\" value=\"${brand}\">` +
-                `<input type=\"hidden\" name=\"washes[${index}][model]\" value=\"${model}\">` +
-                `<input type=\"hidden\" name=\"washes[${index}][color]\" value=\"${color}\">` +
-                `<input type=\"hidden\" name=\"washes[${index}][year]\" value=\"${year}\">` +
-                `<input type=\"hidden\" name=\"washes[${index}][vehicle_type_id]\" value=\"${vehicleTypeId}\">` +
-                `<input type=\"hidden\" name=\"washes[${index}][washer_id]\" value=\"${washerId}\">` +
-                `<input type=\"hidden\" name=\"washes[${index}][tip]\" value=\"${tip.toFixed(2)}\">` +
-                `<div class=\"mt-2 space-y-1 text-sm\"><p>Placa: ${plate}</p><p>Lavador: ${washerName || 'N/A'}</p><p>Servicios: ${servicesText}</p><p>Propina: RD$ ${tip.toFixed(2)}</p></div>`;
+
+            wrapper.dataset.total = total;
+            wrapper.dataset.discount = discount;
+            wrapper.dataset.serviceId = serviceId;
+            wrapper.dataset.priceLabel = priceLabel || '';
+
+            const info = document.createElement('div');
+            info.className = 'flex justify-between items-start gap-4';
+            info.innerHTML = `
+                <div>
+                    <p class="font-semibold text-gray-800">${serviceName}</p>
+                    ${priceLabel ? `<p class="text-sm text-gray-600">${priceLabel}</p>` : ''}
+                    ${washerName ? `<p class="text-sm text-gray-600">Estilista: ${washerName}</p>` : ''}
+                    ${tip > 0 ? `<p class="text-sm text-gray-600">Propina: RD$ ${tip.toFixed(2)}</p>` : ''}
+                    <p class="text-sm font-medium text-gray-800">Subtotal: RD$ ${total.toFixed(2)}</p>
+                </div>
+                <div class="flex gap-2 text-sm">
+                    <button type="button" class="text-blue-600 hover:underline" onclick="editWash(this)">Editar</button>
+                    <button type="button" class="text-red-600 hover:underline" onclick="removeWash(this)">Eliminar</button>
+                </div>
+            `;
+            wrapper.appendChild(info);
+
+            const hiddenFields = [
+                createHiddenInput('service_id', serviceId),
+                createHiddenInput('service_price_id', priceOption ? priceOption.id : ''),
+                createHiddenInput('washer_id', washerId || ''),
+                createHiddenInput('tip', tip.toFixed(2))
+            ];
+            hiddenFields.forEach(input => wrapper.appendChild(input));
 
             updateWashIndexes();
-
-            form.querySelectorAll('input[type=text], input[type=number]').forEach(el=>el.value='');
-            form.querySelectorAll('select').forEach(sel=>{sel.value=''; if(sel._searchInput) sel._searchInput.value='';});
-            form.querySelectorAll('input[type=checkbox]').forEach(cb=>cb.checked=false);
-            delete form.dataset.editIndex;
-            document.getElementById('wash-list').after(form);
-            form.classList.add('hidden');
-            document.getElementById('show-wash-form-btn').classList.remove('hidden');
-            document.getElementById('cancel-wash-btn').classList.add('hidden');
-            document.getElementById('save-wash-btn').textContent = 'Agregar lavado';
-            wrapper.removeAttribute('open');
+            resetWashForm();
+            cancelWashForm();
             updateTotal();
         }
 
-        function editWash(wrapper) {
-            const index = Array.from(document.querySelectorAll('.wash-item')).indexOf(wrapper);
+        function editWash(btn) {
+            const wrapper = btn.closest('.wash-item');
+            const index = Array.from(document.querySelectorAll('#wash-list .wash-item')).indexOf(wrapper);
             const form = document.getElementById('wash-form');
             form.dataset.editIndex = index;
-            document.getElementById('show-wash-form-btn').classList.add('hidden');
-            document.getElementById('cancel-wash-btn').classList.add('hidden');
             document.getElementById('save-wash-btn').textContent = 'Guardar cambios';
-            form.classList.remove('hidden');
-            wrapper.appendChild(form);
-            form.querySelector('input[name="temp_plate"]').value = wrapper.querySelector(`input[name="washes[${index}][plate]"]`).value;
-            form.querySelector('input[name="temp_brand"]').value = wrapper.querySelector(`input[name="washes[${index}][brand]"]`).value;
-            form.querySelector('input[name="temp_model"]').value = wrapper.querySelector(`input[name="washes[${index}][model]"]`).value;
-            form.querySelector('input[name="temp_color"]').value = wrapper.querySelector(`input[name="washes[${index}][color]"]`).value;
-            form.querySelector('input[name="temp_year"]').value = wrapper.querySelector(`input[name="washes[${index}][year]"]`).value;
-            form.querySelector('select[name="temp_vehicle_type_id"]').value = wrapper.querySelector(`input[name="washes[${index}][vehicle_type_id]"]`).value;
-            const washerSelect = form.querySelector('select[name="temp_washer_id"]');
-            washerSelect.value = wrapper.querySelector(`input[name="washes[${index}][washer_id]"]`).value;
-            if(washerSelect._searchInput){ washerSelect._searchInput.value = washerSelect.options[washerSelect.selectedIndex]?.text || ''; }
-            form.querySelectorAll('input[name="temp_service_ids[]"]').forEach(cb=>{
-                const val = cb.value;
-                cb.checked = wrapper.querySelector(`input[name="washes[${index}][service_ids][]"][value="${val}"]`) !== null;
-            });
-            form.querySelector('input[name="temp_tip"]').value = wrapper.querySelector(`input[name="washes[${index}][tip]"]`).value;
 
-            document.querySelectorAll('.wash-item').forEach(w=>{ if(w!==wrapper) w.removeAttribute('open'); });
+            const serviceId = wrapper.querySelector('input[data-field="service_id"]').value;
+            const priceId = wrapper.querySelector('input[data-field="service_price_id"]').value;
+            const washerId = wrapper.querySelector('input[data-field="washer_id"]').value;
+            const tip = wrapper.querySelector('input[data-field="tip"]').value;
+
+            const serviceSelect = form.querySelector('select[name="temp_service_id"]');
+            serviceSelect.value = serviceId;
+            handleTempServiceChange(serviceSelect);
+
+            const priceSelect = form.querySelector('select[name="temp_service_price_id"]');
+            if (priceId) {
+                priceSelect.value = priceId;
+                updateTempPriceDisplay();
+            }
+
+            const washerSelect = form.querySelector('select[name="temp_washer_id"]');
+            washerSelect.value = washerId;
+            if (washerSelect._searchInput) {
+                washerSelect._searchInput.value = washerSelect.options[washerSelect.selectedIndex]?.text || '';
+            }
+            form.querySelector('input[name="temp_tip"]').value = tip;
+
+            showWashForm();
         }
 
         function removeWash(btn) {
@@ -597,13 +656,9 @@
 
         function updateWashIndexes(){
             document.querySelectorAll('#wash-list .wash-item').forEach((item,i)=>{
-                item.querySelectorAll('input[name^="washes["]').forEach(input=>{
-                    const field = input.name.replace(/washes\[\d+\]\[(.*)\]/,'$1');
-                    if(field.startsWith('service_ids')){
-                        input.name = `washes[${i}][service_ids][]`;
-                    }else{
-                        input.name = `washes[${i}][${field}]`;
-                    }
+                item.dataset.index = i;
+                item.querySelectorAll('input[data-field]').forEach(input=>{
+                    input.name = `washes[${i}][${input.dataset.field}]`;
                 });
             });
         }
@@ -614,14 +669,8 @@
             field.style.display = method === 'transferencia' ? '' : 'none';
         }
 
-        const plateInput = document.getElementById('plate');
         const nameInput = document.querySelector('input[name="customer_name"]');
         const phoneInput = document.querySelector('input[name="customer_phone"]');
-        const colorInput = document.querySelector('input[name="temp_color"]');
-        const yearInput = document.querySelector('input[name="temp_year"]');
-        const plateList = document.getElementById('plate-options');
-        let plateData = [];
-        let selectedIndex = -1;
 
         function restrictInput(el, keyRegex, pasteRegex, msg){
             el.addEventListener('keydown', e => {
@@ -645,9 +694,6 @@
         }
 
         restrictInput(nameInput, /^[A-Za-zÁÉÍÓÚáéíóúñÑ ]$/, /^[A-Za-zÁÉÍÓÚáéíóúñÑ ]+$/, 'El nombre solo puede contener letras');
-        restrictInput(plateInput, /^[A-Za-z0-9]$/, /^[A-Za-z0-9]+$/, 'La placa solo puede contener letras y números');
-        restrictInput(colorInput, /^[A-Za-zÁÉÍÓÚáéíóúñÑ ]$/, /^[A-Za-zÁÉÍÓÚáéíóúñÑ ]+$/, 'El color solo puede contener letras');
-        restrictInput(yearInput, /^\d$/, /^\d+$/, 'El año solo puede contener números');
         restrictInput(phoneInput, /^[0-9+() -]$/, /^[0-9+() -]+$/, 'El teléfono solo puede contener números');
 
         function convertSelectToSearchable(select){
@@ -672,102 +718,6 @@
             list.addEventListener('mousedown', e=>{const li=e.target.closest('li'); if(!li) return; e.preventDefault(); input.value=li.textContent; select.value=li.dataset.val; select.dispatchEvent(new Event('change')); list.classList.add('hidden');});
             input.addEventListener('blur', ()=>setTimeout(()=>list.classList.add('hidden'),200));
         }
-
-        const maxYear = {{ date('Y') }};
-        const minYear = 1890;
-        yearInput.addEventListener('input', () => {
-            let val = yearInput.value.replace(/\D/g, '').slice(0, 4);
-            yearInput.value = val;
-            if (val.length === 4) {
-                const num = parseInt(val, 10);
-                if (num < minYear || num > maxYear) {
-                    yearInput.value = '';
-                    const list = document.getElementById('error-list');
-                    list.innerHTML = `<li>El año debe estar entre ${minYear} y ${maxYear}</li>`;
-                    window.dispatchEvent(new CustomEvent('open-modal', { detail: 'error-modal' }));
-                }
-            }
-        });
-
-        plateInput.addEventListener('input', async () => {
-            const q = plateInput.value.trim();
-            if (!q) { plateList.innerHTML = ''; plateList.classList.add('hidden'); return; }
-            try {
-                const res = await fetch(`{{ route('vehicles.search') }}?plate=${encodeURIComponent(q)}`, {headers:{'Accept':'application/json'}});
-                if(res.ok){
-                    plateData = (await res.json()).slice(0,10);
-                    plateList.innerHTML = '';
-                    selectedIndex = -1;
-                    if(plateData.length === 0){
-                        plateList.classList.add('hidden');
-                        return;
-                    }
-                    plateList.classList.remove('hidden');
-                    plateData.forEach(v => {
-                        const li = document.createElement('li');
-                        li.textContent = `${v.brand} | ${v.model} | ${v.color} | ${v.year ?? ''} | ${v.plate} | ${v.type}`;
-                        li.dataset.plate = v.plate;
-                        li.className = 'px-2 py-1 cursor-pointer hover:bg-gray-200';
-                        plateList.appendChild(li);
-                    });
-                }
-            } catch(e) {}
-        });
-
-        plateInput.addEventListener('keydown', e => {
-            const items = plateList.querySelectorAll('li');
-            if(plateList.classList.contains('hidden') || items.length === 0) return;
-            if(e.key === 'ArrowDown'){
-                e.preventDefault();
-                selectedIndex = (selectedIndex + 1) % items.length;
-                updateActive(items);
-            } else if(e.key === 'ArrowUp'){
-                e.preventDefault();
-                selectedIndex = (selectedIndex - 1 + items.length) % items.length;
-                updateActive(items);
-            } else if(e.key === 'Enter' && selectedIndex >= 0){
-                e.preventDefault();
-                const li = items[selectedIndex];
-                plateInput.value = li.dataset.plate;
-                fillVehicleFields(li.dataset.plate);
-                plateList.classList.add('hidden');
-            }
-        });
-
-        function updateActive(items){
-            items.forEach((li,i)=>{
-                li.classList.toggle('bg-gray-200', i===selectedIndex);
-            });
-        }
-
-        plateList.addEventListener('mousedown', e => {
-            const li = e.target.closest('li[data-plate]');
-            if(!li) return;
-            e.preventDefault();
-            plateInput.value = li.dataset.plate;
-            fillVehicleFields(li.dataset.plate);
-            plateList.classList.add('hidden');
-        });
-
-        plateInput.addEventListener('blur', () => {
-            setTimeout(() => plateList.classList.add('hidden'), 200);
-        });
-
-        plateInput.addEventListener('change', () => {
-            fillVehicleFields(plateInput.value);
-        });
-
-        function fillVehicleFields(plate){
-            const found = plateData.find(v => v.plate === plate);
-            if(found){
-                document.querySelector('input[name="temp_brand"]').value = found.brand;
-                document.querySelector('input[name="temp_model"]').value = found.model;
-                document.querySelector('input[name="temp_color"]').value = found.color;
-                document.querySelector('input[name="temp_year"]').value = found.year || '';
-                document.querySelector('select[name="temp_vehicle_type_id"]').value = found.vehicle_type_id;
-            }
-        }
-
 
         document.querySelectorAll('select[data-searchable]').forEach(convertSelectToSearchable);
 

--- a/resources/views/tickets/partials/table.blade.php
+++ b/resources/views/tickets/partials/table.blade.php
@@ -59,7 +59,7 @@
             @endphp
             @if($hasCommission || $hasTip)
             <div class="space-y-2 text-sm">
-                <label class="block font-medium">¿Desea pagar la comisión o propina al lavador de todos modos?</label>
+                <label class="block font-medium">¿Desea pagar la comisión o propina al estilista de todos modos?</label>
                 <select name="pay_washer" class="form-select w-full" required>
                     <option value=""></option>
                     <option value="yes">Si</option>
@@ -176,7 +176,7 @@
                             @endif
                             @if($canChangeWasher)
                             <div class="mt-1">
-                                <label class="block text-sm font-medium text-gray-700">Lavador</label>
+                                <label class="block text-sm font-medium text-gray-700">Estilista</label>
                                 <select name="washers[{{ $wash->id }}]" class="form-select w-full">
                                     <option value="">-- Seleccionar --</option>
                                     @foreach($washers as $w)

--- a/resources/views/washers/create.blade.php
+++ b/resources/views/washers/create.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Nuevo Lavador') }}
+            {{ __('Nuevo Estilista') }}
         </h2>
     </x-slot>
 

--- a/resources/views/washers/edit.blade.php
+++ b/resources/views/washers/edit.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Editar Lavador') }}
+            {{ __('Editar Estilista') }}
         </h2>
     </x-slot>
 

--- a/resources/views/washers/index.blade.php
+++ b/resources/views/washers/index.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Lavadores') }}
+            {{ __('Estilistas') }}
         </h2>
     </x-slot>
 
@@ -26,7 +26,7 @@
                         ">Hoy</button>
                     </div>
                 </form>
-                <a href="{{ route('washers.create') }}" class="btn-primary">Nuevo Lavador</a>
+                <a href="{{ route('washers.create') }}" class="btn-primary">Nuevo Estilista</a>
             </div>
 
             <div x-html="tableHtml"></div>

--- a/resources/views/washers/show.blade.php
+++ b/resources/views/washers/show.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Lavador') }}: {{ $washer->name }}
+            {{ __('Estilista') }}: {{ $washer->name }}
         </h2>
     </x-slot>
 
@@ -20,7 +20,7 @@
 
         <div class="mb-4 flex justify-end space-x-2">
             <a href="{{ route('washers.edit', $washer) }}" class="px-4 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600">Editar</a>
-            <form action="{{ route('washers.destroy', $washer) }}" method="POST" onsubmit="return confirm('¿Eliminar lavador?')">
+            <form action="{{ route('washers.destroy', $washer) }}" method="POST" onsubmit="return confirm('¿Eliminar estilista?')">
                 @csrf
                 @method('DELETE')
                 <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700">Eliminar</button>

--- a/tests/Feature/DashboardWasherPayDuePaidTest.php
+++ b/tests/Feature/DashboardWasherPayDuePaidTest.php
@@ -22,7 +22,7 @@ class DashboardWasherPayDuePaidTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2024-01-01 10:00:00'));
         $user = User::factory()->create(['role' => 'admin']);
-        $washer = Washer::create(['name' => 'Lavador', 'pending_amount' => 0, 'active' => true]);
+        $washer = Washer::create(['name' => 'Estilista', 'pending_amount' => 0, 'active' => true]);
         $vehicleType = VehicleType::create(['name' => 'Car']);
         $service = Service::create(['name' => 'Lavado', 'description' => 'Lavado', 'active' => true]);
 

--- a/tests/Feature/GrossProfitTest.php
+++ b/tests/Feature/GrossProfitTest.php
@@ -104,7 +104,7 @@ class GrossProfitTest extends TestCase
         $user = User::factory()->create(['role' => 'admin']);
 
         $washer = Washer::create([
-            'name' => 'Lavador',
+            'name' => 'Estilista',
             'pending_amount' => 0,
             'active' => true,
         ]);

--- a/tests/Feature/TicketCancelKeepPaymentsTest.php
+++ b/tests/Feature/TicketCancelKeepPaymentsTest.php
@@ -22,7 +22,7 @@ class TicketCancelKeepPaymentsTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2024-01-01 10:00:00'));
         $user = User::factory()->create(['role' => 'admin']);
-        $washer = Washer::create(['name' => 'Lavador', 'pending_amount' => 0, 'active' => true]);
+        $washer = Washer::create(['name' => 'Estilista', 'pending_amount' => 0, 'active' => true]);
         $vehicleType = VehicleType::create(['name' => 'Car']);
         $service = Service::create(['name' => 'Lavado', 'description' => 'Lavado', 'active' => true]);
 
@@ -126,7 +126,7 @@ class TicketCancelKeepPaymentsTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2024-01-01 10:00:00'));
         $user = User::factory()->create(['role' => 'admin']);
-        $washer = Washer::create(['name' => 'Lavador', 'pending_amount' => 0, 'active' => true]);
+        $washer = Washer::create(['name' => 'Estilista', 'pending_amount' => 0, 'active' => true]);
         $vehicleType = VehicleType::create(['name' => 'Car']);
         $service = Service::create(['name' => 'Lavado', 'description' => 'Lavado', 'active' => true]);
 

--- a/tests/Feature/TicketCancelRecoverPaymentsTest.php
+++ b/tests/Feature/TicketCancelRecoverPaymentsTest.php
@@ -22,7 +22,7 @@ class TicketCancelRecoverPaymentsTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2024-02-01 10:00:00'));
         $user = User::factory()->create(['role' => 'admin']);
-        $washer = Washer::create(['name' => 'Lavador', 'pending_amount' => 0, 'active' => true]);
+        $washer = Washer::create(['name' => 'Estilista', 'pending_amount' => 0, 'active' => true]);
         $vehicleType = VehicleType::create(['name' => 'Car']);
         $service = Service::create(['name' => 'Lavado', 'description' => 'Lavado', 'active' => true]);
 

--- a/tests/Feature/TicketEditTipExtraTest.php
+++ b/tests/Feature/TicketEditTipExtraTest.php
@@ -28,7 +28,7 @@ class TicketEditTipExtraTest extends TestCase
         $vehicleType = VehicleType::create(['name' => 'Carro']);
         $washer = Washer::create(['name' => 'Juan', 'pending_amount' => 0, 'active' => true]);
         $service = Service::create(['name' => 'Lavado', 'description' => 'test', 'active' => true]);
-        ServicePrice::create(['service_id' => $service->id, 'vehicle_type_id' => $vehicleType->id, 'price' => 200]);
+        ServicePrice::create(['service_id' => $service->id, 'vehicle_type_id' => $vehicleType->id, 'label' => 'Carro', 'price' => 200]);
 
         $date = Carbon::parse('2024-01-10');
 

--- a/tests/Feature/WasherDebtTest.php
+++ b/tests/Feature/WasherDebtTest.php
@@ -25,7 +25,7 @@ class WasherDebtTest extends TestCase
         $user = User::factory()->create(['role' => 'admin']);
 
         $washer = Washer::create([
-            'name' => 'Lavador',
+            'name' => 'Estilista',
             'pending_amount' => 0,
             'active' => true,
         ]);


### PR DESCRIPTION
## Summary
- rename the ticket services section heading to "Servicios" for consistency
- require explicit price option selection for each service when creating or updating tickets and surface clear validation errors
- stop falling back to implicit price selections and guard both UI and backend flows when a service lacks configured price options

## Testing
- php artisan test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68cf177a0f94832a9543081dde710119