### PR TITLE
Add appearance settings management with logo cache busting

### DIFF
--- a/app/Http/Controllers/AppearanceController.php
+++ b/app/Http/Controllers/AppearanceController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\AppearanceSetting;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 
 class AppearanceController extends Controller
 {
@@ -13,7 +15,9 @@ class AppearanceController extends Controller
 
     public function index()
     {
-        return view('appearance.index');
+        $settings = AppearanceSetting::first();
+
+        return view('appearance.index', compact('settings'));
     }
 
     public function store(Request $request)
@@ -21,19 +25,35 @@ class AppearanceController extends Controller
         $request->validate([
             'logo' => 'nullable|image|max:1024',
             'favicon' => 'nullable|file|max:512',
+            'business_name' => 'nullable|string|max:255',
         ]);
+
+        $settings = AppearanceSetting::first() ?? new AppearanceSetting();
 
         if ($request->hasFile('logo')) {
             $dir = public_path('images');
-            if (!file_exists($dir)) {
+            if (! file_exists($dir)) {
                 mkdir($dir, 0755, true);
             }
+
             $request->file('logo')->move($dir, 'logo.png');
+            $settings->logo_updated_at = now();
         }
 
         if ($request->hasFile('favicon')) {
             $request->file('favicon')->move(public_path(), 'favicon.ico');
+            $settings->favicon_updated_at = now();
         }
+
+        if ($request->has('business_name')) {
+            $settings->business_name = $request->filled('business_name')
+                ? $request->input('business_name')
+                : null;
+        }
+
+        $settings->save();
+
+        Cache::forget('appearance_settings');
 
         return back()->with('success', 'Apariencia actualizada.');
     }

--- a/app/Models/AppearanceSetting.php
+++ b/app/Models/AppearanceSetting.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AppearanceSetting extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $guarded = [];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'logo_updated_at' => 'datetime',
+        'favicon_updated_at' => 'datetime',
+    ];
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Models\AppearanceSetting;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +23,16 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        View::composer('*', function ($view) {
+            $settings = Cache::remember('appearance_settings', 300, function () {
+                if (! Schema::hasTable('appearance_settings')) {
+                    return null;
+                }
+
+                return AppearanceSetting::first();
+            });
+
+            $view->with('appearanceSettings', $settings);
+        });
     }
 }

--- a/database/migrations/2025_09_21_100306_create_appearance_settings_table.php
+++ b/database/migrations/2025_09_21_100306_create_appearance_settings_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('appearance_settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('business_name')->nullable();
+            $table->timestamp('logo_updated_at')->nullable();
+            $table->timestamp('favicon_updated_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('appearance_settings');
+    }
+};

--- a/resources/views/appearance/index.blade.php
+++ b/resources/views/appearance/index.blade.php
@@ -10,6 +10,11 @@
             <form method="POST" action="{{ route('appearance.store') }}" enctype="multipart/form-data" class="space-y-6">
                 @csrf
                 <div>
+                    <label class="block font-medium text-sm text-gray-700">Nombre del negocio</label>
+                    <input type="text" name="business_name" value="{{ old('business_name', optional($settings)->business_name) }}" class="form-input mt-1 w-full" placeholder="Ej. Salon Soma">
+                    <p class="text-xs text-gray-500 mt-1">Este nombre se mostrará en el pie de página.</p>
+                </div>
+                <div>
                     <label class="block font-medium text-sm text-gray-700">Logo</label>
                     <input type="file" name="logo" class="form-input mt-1">
                     <p class="text-xs text-gray-500 mt-1">Tamaño recomendado: 200x50 px.</p>

--- a/resources/views/components/application-logo.blade.php
+++ b/resources/views/components/application-logo.blade.php
@@ -1,1 +1,9 @@
-<img src="{{ asset('images/logo.png') }}" alt="Logo" {{ $attributes }}>
+@php
+    $logoUrl = asset('images/logo.png');
+    $cacheBuster = optional($appearanceSettings)->logo_updated_at?->timestamp;
+
+    if ($cacheBuster) {
+        $logoUrl .= '?v=' . $cacheBuster;
+    }
+@endphp
+<img src="{{ $logoUrl }}" alt="Logo" {{ $attributes }}>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -22,7 +22,7 @@
             <div x-show="sidebarOpen" x-cloak class="fixed inset-0 bg-black/50 z-30 md:hidden" @click="sidebarOpen = false"></div>
             @include('layouts.sidebar')
 
-            <div class="flex-1">
+            <div class="flex-1 flex flex-col min-h-screen">
                 @include('layouts.navigation')
                 @include('partials.flash-messages')
 
@@ -36,11 +36,14 @@
             @endif
 
                 <!-- Page Content -->
-                <main>
+                <main class="flex-1">
                     {{ $slot }}
                 </main>
-                <footer class="bg-gray-100 text-sm px-4 py-2 flex justify-between items-center">
-                    <span>&copy; {{ date('Y') }} 3Glam</span>
+                @php
+                    $businessName = optional($appearanceSettings)->business_name;
+                @endphp
+                <footer class="bg-gray-100 text-sm px-4 py-2 flex justify-between items-center mt-auto">
+                    <span>&copy; 2025{{ $businessName ? ' ' . $businessName : '' }}</span>
                     <img src="{{ asset('images/signature.png') }}" alt="Firma" class="h-10">
                 </footer>
             </div>


### PR DESCRIPTION
## Summary
- add a dedicated appearance settings table and model to persist the business name and asset timestamps
- update the appearance configuration screen to edit the business name alongside logo and favicon uploads
- share appearance settings across layouts to display the uploaded logo with cache busting and pin the footer with the configured business name

## Testing
- php artisan test *(fails: existing migration 2025_09_01_000000_add_label_to_service_prices_table references vehicle_types.name in sqlite)*

------
https://chatgpt.com/codex/tasks/task_e_68d005378a2c832ab37a0ee8f4fa729c