### PR TITLE
Enable paid ticket stylist reassignment and inventory tweaks

### DIFF
--- a/app/Http/Controllers/PettyCashExpenseController.php
+++ b/app/Http/Controllers/PettyCashExpenseController.php
@@ -11,6 +11,7 @@ class PettyCashExpenseController extends Controller
     public function __construct()
     {
         $this->middleware(['auth', 'role:admin,cajero']);
+        $this->middleware('role:admin')->only('destroy');
     }
 
     public function index(Request $request)
@@ -122,6 +123,10 @@ class PettyCashExpenseController extends Controller
 
     public function destroy(PettyCashExpense $pettyCash)
     {
+        if (auth()->user()->role !== 'admin') {
+            abort(403);
+        }
+
         $pettyCash->delete();
         return redirect()->route('petty-cash.index')
             ->with('success', 'Gasto eliminado correctamente.');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "CarWashApp",
+    "name": "SomaBeauty",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/views/inventory/create.blade.php
+++ b/resources/views/inventory/create.blade.php
@@ -19,7 +19,7 @@
             @csrf
             <div>
                 <label for="product_id" class="block font-medium text-sm text-gray-700">Producto</label>
-                <select name="product_id" class="form-input w-full">
+                <select name="product_id" class="form-input w-full" data-searchable data-placeholder="-- Seleccionar --">
                     @foreach ($products as $product)
                         <option value="{{ $product->id }}" @selected(request('product_id') == $product->id)>
                             {{ $product->name }}
@@ -37,4 +37,11 @@
             </div>
         </form>
     </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            if (window.initSearchableSelects) {
+                window.initSearchableSelects();
+            }
+        });
+    </script>
 </x-app-layout>

--- a/resources/views/inventory/create_exit.blade.php
+++ b/resources/views/inventory/create_exit.blade.php
@@ -19,7 +19,7 @@
             @csrf
             <div>
                 <label for="product_id" class="block font-medium text-sm text-gray-700">Producto</label>
-                <select name="product_id" class="form-input w-full">
+                <select name="product_id" class="form-input w-full" data-searchable data-placeholder="-- Seleccionar --">
                     @foreach ($products as $product)
                         <option value="{{ $product->id }}" @selected(request('product_id') == $product->id)>
                             {{ $product->name }}
@@ -41,4 +41,11 @@
             </div>
         </form>
     </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            if (window.initSearchableSelects) {
+                window.initSearchableSelects();
+            }
+        });
+    </script>
 </x-app-layout>

--- a/resources/views/petty_cash/partials/table.blade.php
+++ b/resources/views/petty_cash/partials/table.blade.php
@@ -15,11 +15,15 @@
                     <td class="px-4 py-2">{{ $expense->description }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($expense->amount, 2) }}</td>
                     <td class="px-4 py-2">
-                        <form action="{{ route('petty-cash.destroy', $expense) }}" method="POST" onsubmit="return confirm('¿Eliminar este gasto?')">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-600 hover:underline">Eliminar</button>
-                        </form>
+                        @if (auth()->user()->role === 'admin')
+                            <form action="{{ route('petty-cash.destroy', $expense) }}" method="POST" onsubmit="return confirm('¿Eliminar este gasto?')">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="text-red-600 hover:underline">Eliminar</button>
+                            </form>
+                        @else
+                            <span class="text-sm text-gray-500">Solo administradores</span>
+                        @endif
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -22,6 +22,9 @@
                 <button x-show="selected" x-on:click="$dispatch('open-modal', 'entry-' + selected)" class="text-blue-600" title="Entrada">
                     <i class="fa-solid fa-plus fa-lg"></i>
                 </button>
+                <button x-show="selected" x-on:click="$dispatch('open-modal', 'exit-' + selected)" class="text-purple-600" title="Salida">
+                    <i class="fa-solid fa-minus fa-lg"></i>
+                </button>
             </div>
         @endif
 
@@ -69,6 +72,28 @@
                     <div>
                         <label class="block font-medium text-sm text-gray-700">Cantidad</label>
                         <input type="number" name="quantity" min="1" required class="form-input w-full">
+                    </div>
+                    <div class="mt-6 flex justify-end">
+                        <x-secondary-button x-on:click="$dispatch('close')">Cancelar</x-secondary-button>
+                        <x-primary-button class="ms-3">Guardar</x-primary-button>
+                    </div>
+                </form>
+            </x-modal>
+
+            <x-modal name="exit-{{ $product->id }}" focusable>
+                <form method="POST" action="{{ route('inventory.storeExit') }}" class="p-6 space-y-6">
+                    @csrf
+                    <input type="hidden" name="product_id" value="{{ $product->id }}">
+                    <div>
+                        <p class="text-sm text-gray-600">Stock actual: {{ $product->stock }}</p>
+                    </div>
+                    <div>
+                        <label class="block font-medium text-sm text-gray-700">Cantidad</label>
+                        <input type="number" name="quantity" min="1" required class="form-input w-full">
+                    </div>
+                    <div>
+                        <label class="block font-medium text-sm text-gray-700">Concepto</label>
+                        <input type="text" name="concept" required class="form-input w-full">
                     </div>
                     <div class="mt-6 flex justify-end">
                         <x-secondary-button x-on:click="$dispatch('close')">Cancelar</x-secondary-button>

--- a/resources/views/tickets/partials/table.blade.php
+++ b/resources/views/tickets/partials/table.blade.php
@@ -141,25 +141,21 @@
                 <p><strong>Total:</strong> RD$ {{ number_format($ticket->total_amount, 2) }}</p>
             </div>
             @if($ticket->washes->count())
-                @php
-                    $canChangeWasher = true;
-                    if(!$ticket->pending){
-                        foreach($ticket->washes as $w){
-                            $tipPaid = \App\Models\WasherMovement::where('ticket_id',$ticket->id)
-                                ->where('washer_id',$w->washer_id)
-                                ->where('description','like','[P]%')
-                                ->where('paid',true)
-                                ->exists();
-                            if($w->washer_paid || $tipPaid){ $canChangeWasher = false; break; }
-                        }
-                    }
-                @endphp
                 <div class="space-y-2">
                     @foreach($ticket->washes as $wash)
                         <div class="border rounded p-2 space-y-1">
                             @php
                                 $serviceNames = $wash->details->where('type','service')->map(fn($d)=>$d->service->name ?? 'Servicio')->implode(', ');
                                 $priceLabel = optional($wash->vehicleType)->name;
+                                $tipPaid = false;
+                                if(!$ticket->pending && $wash->washer_id){
+                                    $tipPaid = \App\Models\WasherMovement::where('ticket_id',$ticket->id)
+                                        ->where('washer_id',$wash->washer_id)
+                                        ->where('description','like','[P]%')
+                                        ->where('paid',true)
+                                        ->exists();
+                                }
+                                $canChangeWasher = $ticket->pending || (!$wash->washer_paid && !$tipPaid);
                             @endphp
                             <p class="text-sm font-semibold">
                                 {{ $serviceNames ?: 'Servicio' }}
@@ -180,6 +176,8 @@
                                     @endforeach
                                 </select>
                             </div>
+                            @else
+                                <p class="text-sm text-gray-600">Estilista: {{ optional($wash->washer)->name ?? 'N/A' }}</p>
                             @endif
                         </div>
                     @endforeach


### PR DESCRIPTION
## Summary
- prevent cashiers from deleting petty cash entries and hide the action in the UI
- add an inventory exit flow from the product listing and expose searchable selectors for inventory adjustments
- allow updating stylists on paid tickets when payments to the prior stylist have not been issued, moving commissions and tips accordingly

## Testing
- npm run build
- php artisan test *(fails: several pre-existing feature assertions related to washer accounting)*

------
https://chatgpt.com/codex/tasks/task_e_68d0bf571e1c832abdbf16c0229df624