### PR TITLE
Add printable ticket flow and appearance fields for business details

### DIFF
--- a/app/Http/Controllers/AppearanceController.php
+++ b/app/Http/Controllers/AppearanceController.php
@@ -27,6 +27,8 @@ class AppearanceController extends Controller
             'login_logo' => 'nullable|image|max:1024',
             'favicon' => 'nullable|file|max:512',
             'business_name' => 'nullable|string|max:255',
+            'business_address' => 'nullable|string|max:500',
+            'tax_id' => 'nullable|string|max:100',
         ]);
 
         $settings = AppearanceSetting::first() ?? new AppearanceSetting();
@@ -59,6 +61,18 @@ class AppearanceController extends Controller
         if ($request->has('business_name')) {
             $settings->business_name = $request->filled('business_name')
                 ? $request->input('business_name')
+                : null;
+        }
+
+        if ($request->has('business_address')) {
+            $settings->business_address = $request->filled('business_address')
+                ? trim($request->input('business_address'))
+                : null;
+        }
+
+        if ($request->has('tax_id')) {
+            $settings->tax_id = $request->filled('tax_id')
+                ? trim($request->input('tax_id'))
                 : null;
         }
 

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -411,7 +411,104 @@ class TicketController extends Controller
             'paid_at' => $ticket->created_at,
         ]);
 
-        return redirect()->route('tickets.index')->with('success', 'Ticket pagado correctamente.');
+        return redirect()->route('tickets.index')
+            ->with('success', 'Ticket pagado correctamente.')
+            ->with('print_ticket_url', route('tickets.print', $ticket));
+    }
+
+    public function print(Ticket $ticket)
+    {
+        if ($ticket->pending || $ticket->canceled) {
+            abort(404);
+        }
+
+        $ticket->load([
+            'user',
+            'details.service',
+            'details.product',
+            'details.drink',
+            'details.wash.vehicleType',
+            'washes.details.service',
+            'washes.washer',
+            'washes.vehicleType',
+            'bankAccount',
+        ]);
+
+        $items = [];
+
+        foreach ($ticket->details as $detail) {
+            $amount = $detail->subtotal;
+            $quantity = $detail->quantity ?? 1;
+
+            switch ($detail->type) {
+                case 'service':
+                    $serviceName = optional($detail->service)->name ?? 'Servicio';
+                    $priceLabel = optional(optional($detail->wash)->vehicleType)->name;
+                    $description = $priceLabel
+                        ? sprintf('%s (%s)', $serviceName, $priceLabel)
+                        : $serviceName;
+                    $items[] = [
+                        'qty' => $quantity,
+                        'description' => $description,
+                        'amount' => $amount,
+                    ];
+                    break;
+                case 'product':
+                    $items[] = [
+                        'qty' => $quantity,
+                        'description' => optional($detail->product)->name ?? 'Producto',
+                        'amount' => $amount,
+                    ];
+                    break;
+                case 'drink':
+                    $items[] = [
+                        'qty' => $quantity,
+                        'description' => optional($detail->drink)->name ?? 'Bebida',
+                        'amount' => $amount,
+                    ];
+                    break;
+                case 'extra':
+                    $items[] = [
+                        'qty' => $quantity,
+                        'description' => $detail->description ?: 'Cargo adicional',
+                        'amount' => $amount,
+                    ];
+                    break;
+            }
+        }
+
+        foreach ($ticket->washes as $wash) {
+            if ($wash->tip > 0) {
+                $serviceNames = $wash->details
+                    ->where('type', 'service')
+                    ->map(fn($d) => optional($d->service)->name ?? 'Servicio')
+                    ->implode(', ');
+                $washerName = optional($wash->washer)->name;
+
+                $parts = array_filter([
+                    'Propina',
+                    $serviceNames ?: null,
+                    $washerName ? 'para ' . $washerName : null,
+                ]);
+
+                $items[] = [
+                    'qty' => 1,
+                    'description' => implode(' ', $parts),
+                    'amount' => $wash->tip,
+                ];
+            }
+        }
+
+        $subtotalBeforeDiscount = $ticket->total_amount + $ticket->discount_total;
+        $paidAt = $ticket->paid_at ?? $ticket->created_at;
+
+        return view('tickets.print', [
+            'ticket' => $ticket,
+            'items' => $items,
+            'subtotalBeforeDiscount' => $subtotalBeforeDiscount,
+            'paidAt' => $paidAt,
+            'totalDiscount' => $ticket->discount_total,
+        ]);
     }
 
     public function cancel(Request $request, Ticket $ticket)
@@ -865,7 +962,29 @@ class TicketController extends Controller
                 InventoryMovement::create($mov);
             }
             DB::commit();
-            return redirect()->route('tickets.index')->with('success','Ticket actualizado.');
+
+            $message = 'Ticket actualizado.';
+            $printUrl = $pending ? null : route('tickets.print', $ticket);
+
+            if ($request->expectsJson()) {
+                session()->flash('success', $message);
+                if ($printUrl) {
+                    session()->flash('print_ticket_url', $printUrl);
+                }
+
+                return response()->json([
+                    'message' => $message,
+                    'redirect' => route('tickets.index'),
+                    'print_url' => $printUrl,
+                ]);
+            }
+
+            $redirect = redirect()->route('tickets.index')->with('success', $message);
+            if ($printUrl) {
+                $redirect = $redirect->with('print_ticket_url', $printUrl);
+            }
+
+            return $redirect;
         } catch (\Exception $e) {
             DB::rollBack();
             return back()->with('error','Error actualizando ticket: '.$e->getMessage());
@@ -1240,7 +1359,28 @@ class TicketController extends Controller
 
             DB::commit();
 
-            return redirect()->route('tickets.index')->with('success', 'Ticket generado correctamente.');
+            $message = 'Ticket generado correctamente.';
+            $printUrl = $pending ? null : route('tickets.print', $ticket);
+
+            if ($request->expectsJson()) {
+                session()->flash('success', $message);
+                if ($printUrl) {
+                    session()->flash('print_ticket_url', $printUrl);
+                }
+
+                return response()->json([
+                    'message' => $message,
+                    'redirect' => route('tickets.index'),
+                    'print_url' => $printUrl,
+                ]);
+            }
+
+            $redirect = redirect()->route('tickets.index')->with('success', $message);
+            if ($printUrl) {
+                $redirect = $redirect->with('print_ticket_url', $printUrl);
+            }
+
+            return $redirect;
 
         } catch (\Exception $e) {
             DB::rollBack();

--- a/database/migrations/2025_09_22_000231_add_address_and_tax_fields_to_appearance_settings_table.php
+++ b/database/migrations/2025_09_22_000231_add_address_and_tax_fields_to_appearance_settings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('appearance_settings', function (Blueprint $table) {
+            $table->text('business_address')->nullable()->after('business_name');
+            $table->string('tax_id', 100)->nullable()->after('business_address');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('appearance_settings', function (Blueprint $table) {
+            $table->dropColumn(['business_address', 'tax_id']);
+        });
+    }
+};

--- a/resources/views/appearance/index.blade.php
+++ b/resources/views/appearance/index.blade.php
@@ -12,7 +12,17 @@
                 <div>
                     <label class="block font-medium text-sm text-gray-700">Nombre del negocio</label>
                     <input type="text" name="business_name" value="{{ old('business_name', optional($settings)->business_name) }}" class="form-input mt-1 w-full" placeholder="Ej. Salon Soma">
-                    <p class="text-xs text-gray-500 mt-1">Este nombre se mostrará en el pie de página.</p>
+                    <p class="text-xs text-gray-500 mt-1">Este nombre se mostrará en el pie de página y en la factura.</p>
+                </div>
+                <div>
+                    <label class="block font-medium text-sm text-gray-700">Dirección</label>
+                    <textarea name="business_address" rows="3" class="form-textarea mt-1 w-full" placeholder="Ej. Calle Principal #123, Santo Domingo">{{ old('business_address', optional($settings)->business_address) }}</textarea>
+                    <p class="text-xs text-gray-500 mt-1">Se imprimirá debajo del nombre del negocio en la factura.</p>
+                </div>
+                <div>
+                    <label class="block font-medium text-sm text-gray-700">Número de identificación fiscal</label>
+                    <input type="text" name="tax_id" value="{{ old('tax_id', optional($settings)->tax_id) }}" class="form-input mt-1 w-full" placeholder="Ej. RNC 1-11-11111-1">
+                    <p class="text-xs text-gray-500 mt-1">Aparecerá en la cabecera de la factura.</p>
                 </div>
                 <div>
                     <label class="block font-medium text-sm text-gray-700">Logo</label>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -48,5 +48,17 @@
                 </footer>
             </div>
         </div>
+        @if (session('print_ticket_url'))
+            <script>
+                window.addEventListener('load', () => {
+                    const url = @json(session('print_ticket_url'));
+                    const features = 'width=420,height=720,noopener,noreferrer';
+                    const printWindow = window.open(url, '_blank', features);
+                    if (printWindow) {
+                        printWindow.focus();
+                    }
+                });
+            </script>
+        @endif
     </body>
 </html>

--- a/resources/views/tickets/create.blade.php
+++ b/resources/views/tickets/create.blade.php
@@ -793,16 +793,22 @@
                             },
                             body: new FormData(form, submitter)
                         });
+                        let data = null;
+                        try {
+                            data = await res.clone().json();
+                        } catch (error) {
+                            data = null;
+                        }
+
                         if (res.ok) {
-                            window.location = '{{ route('tickets.index') }}';
+                            const redirectUrl = data?.redirect ?? '{{ route('tickets.index') }}';
+                            window.location = redirectUrl;
                             return;
                         }
-                        if (res.status === 422) {
-                            const data = await res.json();
+                        if (res.status === 422 && data?.errors) {
                             this.errors = Object.values(data.errors).flat();
                         } else {
-                            const data = await res.json().catch(() => ({ message: 'Error inesperado' }));
-                            this.errors = [data.message || 'Error inesperado'];
+                            this.errors = [data?.message || 'Error inesperado'];
                         }
                     } catch (e) {
                         this.errors = ['Error de red'];

--- a/resources/views/tickets/edit.blade.php
+++ b/resources/views/tickets/edit.blade.php
@@ -866,16 +866,22 @@
                             },
                             body: new FormData(form, submitter)
                         });
+                        let data = null;
+                        try {
+                            data = await res.clone().json();
+                        } catch (error) {
+                            data = null;
+                        }
+
                         if (res.ok) {
-                            window.location = '{{ route('tickets.index') }}';
+                            const redirectUrl = data?.redirect ?? '{{ route('tickets.index') }}';
+                            window.location = redirectUrl;
                             return;
                         }
-                        if (res.status === 422) {
-                            const data = await res.json();
+                        if (res.status === 422 && data?.errors) {
                             this.errors = Object.values(data.errors).flat();
                         } else {
-                            const data = await res.json().catch(() => ({ message: 'Error inesperado' }));
-                            this.errors = [data.message || 'Error inesperado'];
+                            this.errors = [data?.message || 'Error inesperado'];
                         }
                     } catch (e) {
                         this.errors = ['Error de red'];

--- a/resources/views/tickets/print.blade.php
+++ b/resources/views/tickets/print.blade.php
@@ -1,0 +1,232 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Ticket #{{ $ticket->id }}</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  @media print {
+    @page { size: 80mm auto; margin: 0 }
+    body { margin: 0 }
+  }
+
+  :root{
+    --ink:#000;
+    --accent:#e85aad;
+  }
+
+  body{
+    font: 14px/1.35 "Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+    background:#f5f5f5;
+    color:var(--ink);
+  }
+
+  .wrap{
+    width: 80mm;
+    margin: 0 auto;
+    background:#fff;
+    border: 1px solid var(--ink);
+    position: relative;
+  }
+
+  .scallop{
+    height: 8mm;
+    background:
+      radial-gradient(circle at 12px 8px, var(--accent) 8px, transparent 8px) 0 0/24px 16px repeat-x,
+      radial-gradient(circle at 12px 8px, var(--accent) 8px, transparent 8px) 12px 8px/24px 16px repeat-x;
+  }
+  .scallop.top{ border-bottom:1px solid var(--ink); }
+  .scallop.bottom{ transform: rotate(180deg); border-top:1px solid var(--ink); }
+
+  .ticket{
+    padding: 10px 10px 6px;
+  }
+
+  .center{ text-align:center; }
+  .muted{ opacity:.85; font-size:12px; }
+
+  .info-grid{
+    display:grid;
+    grid-template-columns:1fr 1fr;
+    gap:4px 8px;
+    margin-bottom:6px;
+  }
+
+  .rule{
+    height: 14px;
+    margin: 6px 0;
+    background:
+      linear-gradient(to right, transparent 0, transparent 6px, var(--ink) 6px, var(--ink) 8px, transparent 8px) 0 7px/16px 1px repeat-x;
+  }
+
+  .title{
+    font-weight: 700;
+    letter-spacing: 1px;
+  }
+
+  .tbl{
+    width:100%;
+    border-collapse: collapse;
+    font-variant-numeric: tabular-nums;
+  }
+  .tbl thead th{
+    text-align:left;
+    font-size:12px;
+    font-weight:600;
+    padding:2px 0 4px;
+    border-bottom:1px dashed var(--ink);
+  }
+  .tbl td{
+    padding:4px 0;
+    vertical-align: top;
+  }
+  .col-qty{ width: 30px; }
+  .col-amt{ width: 70px; text-align:right; }
+
+  .totals{
+    width:100%;
+    font-variant-numeric: tabular-nums;
+  }
+  .totals td{ padding: 2px 0; }
+  .totals .val{ text-align:right; }
+
+  .amount{
+    font-weight:800;
+    font-size:16px;
+  }
+
+  .thanks{
+    text-align:center;
+    margin-top: 6px;
+    font-weight:600;
+    letter-spacing:.5px;
+  }
+
+  .barcode{
+    height: 36px;
+    margin: 6px 6px 10px;
+    background:
+      repeating-linear-gradient(
+        to right,
+        #000 0, #000 2px,
+        transparent 2px, transparent 4px,
+        #000 4px, #000 6px,
+        transparent 6px, transparent 9px
+      );
+  }
+
+  .payment-info{
+    display:grid;
+    grid-template-columns:1fr 1fr;
+    gap:4px 8px;
+    margin-top:6px;
+    font-size:12px;
+  }
+
+  .full{ grid-column: span 2; }
+</style>
+</head>
+<body>
+@php
+    $businessName = optional($appearanceSettings)->business_name ?? config('app.name');
+    $address = optional($appearanceSettings)->business_address;
+    $taxId = optional($appearanceSettings)->tax_id;
+    $paymentLabels = [
+        'efectivo' => 'Efectivo',
+        'tarjeta' => 'Tarjeta',
+        'transferencia' => 'Transferencia',
+        'mixto' => 'Mixto',
+    ];
+    $paymentLabel = $paymentLabels[$ticket->payment_method] ?? 'No especificado';
+    $bankLabel = optional($ticket->bankAccount)?->bank;
+    $bankAccount = optional($ticket->bankAccount)?->account;
+    $customerName = $ticket->customer_name ?: 'Consumidor final';
+    $customerPhone = $ticket->customer_phone;
+    $attendedBy = optional($ticket->user)->name ?? 'N/D';
+@endphp
+  <div class="wrap">
+    <div class="scallop top"></div>
+
+    <div class="ticket">
+      <div class="center">
+        <div class="title">{{ mb_strtoupper($businessName, 'UTF-8') }}</div>
+        @if($address)
+          <div class="muted">{{ $address }}</div>
+        @endif
+      </div>
+
+      <div class="rule"></div>
+
+      <div class="muted info-grid">
+        <div>{{ $paidAt->format('d/m/Y') }}&nbsp; {{ $paidAt->format('h:i A') }}</div>
+        <div style="text-align:right;">Ticket #{{ $ticket->id }}</div>
+        <div>Cliente: {{ $customerName }}</div>
+        <div style="text-align:right;">Atendido: {{ $attendedBy }}</div>
+        @if($customerPhone)
+          <div>Tel: {{ $customerPhone }}</div>
+        @endif
+        <div style="text-align:right;">Pago: {{ $paymentLabel }}</div>
+        @if($taxId)
+          <div class="full" style="text-align:right;">RNC: {{ $taxId }}</div>
+        @endif
+        @if($bankLabel || $bankAccount)
+          <div class="full" style="text-align:right;">Cuenta: {{ trim(($bankLabel ? $bankLabel.' ' : '').($bankAccount ?? '')) }}</div>
+        @endif
+      </div>
+
+      <table class="tbl">
+        <thead>
+          <tr>
+            <th class="col-qty">QTY</th>
+            <th>DESCRIPCIÓN</th>
+            <th class="col-amt">IMP.</th>
+          </tr>
+        </thead>
+        <tbody>
+          @foreach($items as $item)
+            <tr>
+              <td class="col-qty">{{ $item['qty'] }}</td>
+              <td>{{ $item['description'] }}</td>
+              <td class="col-amt">RD$ {{ number_format($item['amount'], 2) }}</td>
+            </tr>
+          @endforeach
+        </tbody>
+      </table>
+
+      <div class="rule"></div>
+
+      <table class="totals">
+        <tr>
+          <td>Subtotal :</td>
+          <td class="val">RD$ {{ number_format($subtotalBeforeDiscount, 2) }}</td>
+        </tr>
+        <tr>
+          <td>Descuento :</td>
+          <td class="val">RD$ {{ number_format($totalDiscount, 2) }}</td>
+        </tr>
+      </table>
+
+      <div style="display:flex; justify-content:space-between; align-items:center; margin:6px 0 2px;">
+        <div class="amount">TOTAL</div>
+        <div class="amount">RD$ {{ number_format($ticket->total_amount, 2) }}</div>
+      </div>
+
+      <div class="payment-info muted">
+        <div>Pagado: RD$ {{ number_format($ticket->paid_amount, 2) }}</div>
+        <div style="text-align:right;">Cambio: RD$ {{ number_format($ticket->change, 2) }}</div>
+        <div class="full" style="text-align:center;">Método: {{ $paymentLabel }}</div>
+      </div>
+
+      <div class="thanks">*** ¡GRACIAS POR PREFERIRNOS! ***</div>
+
+      <div class="barcode" aria-hidden="true"></div>
+    </div>
+
+    <div class="scallop bottom"></div>
+  </div>
+
+  <script>
+    window.onload = () => window.print();
+  </script>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,6 +68,7 @@ Route::middleware(['auth', 'role:admin,cajero'])->group(function () {
     Route::get('tickets/pending', [TicketController::class, 'pending'])->name('tickets.pending');
     Route::post('tickets/{ticket}/pay', [TicketController::class, 'pay'])->name('tickets.pay');
     Route::post('tickets/{ticket}/cancel', [TicketController::class, 'cancel'])->name('tickets.cancel');
+    Route::get('tickets/{ticket}/print', [TicketController::class, 'print'])->name('tickets.print');
     Route::resource('tickets', TicketController::class);
     Route::resource('petty-cash', PettyCashExpenseController::class)->except(['show', 'edit', 'update']);
 });


### PR DESCRIPTION
## Summary
- add business address and tax ID fields to appearance settings and expose them in the admin form
- create a printable ticket template for thermal printers and expose a tickets.print route triggered when payments are completed
- adjust ticket creation/edit flows to return JSON metadata for AJAX submissions and open the print window after redirect via layout script
- ensure a migration adds the new appearance columns

## Testing
- php artisan test *(fails: several washer-related feature tests currently red, see run for details)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c9634e38832aa0f24f55e4a1b8db