### PR TITLE
Allow paid ticket invoices to be reprinted

### DIFF
--- a/app/Http/Controllers/AppSettingController.php
+++ b/app/Http/Controllers/AppSettingController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\AppSetting;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class AppSettingController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware(['auth', 'role:admin']);
+    }
+
+    public function updateMobileAccess(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'block_mobile_devices' => ['required', 'in:0,1'],
+        ]);
+
+        AppSetting::updateBlockMobileDevices((bool) (int) $data['block_mobile_devices']);
+
+        return back()->with(
+            'success',
+            $data['block_mobile_devices'] === '1'
+                ? 'El acceso desde dispositivos móviles ha sido restringido.'
+                : 'El acceso desde dispositivos móviles ha sido habilitado.'
+        );
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -11,6 +11,7 @@ use App\Models\WasherPayment;
 use App\Models\BankAccount;
 use App\Models\Washer;
 use App\Models\WasherMovement;
+use App\Models\Product;
 
 class DashboardController extends Controller
 {
@@ -216,6 +217,8 @@ class DashboardController extends Controller
         $grossProfit = $totalFacturado - $pettyCashAmount - $washerPayTotal;
         $grossProfit -= $washerDebtAmount + $assignedPendingCommission;
 
+        $lowStockCount = Product::lowStock()->count();
+
         if ($request->ajax()) {
             return view('dashboard.partials.summary', compact(
                 'totalFacturado',
@@ -234,7 +237,8 @@ class DashboardController extends Controller
                 'accountsReceivable',
                 'pendingTickets',
                 'washerDebts',
-                'pettyCashAmount'
+                'pettyCashAmount',
+                'lowStockCount'
             ));
         }
 
@@ -257,6 +261,7 @@ class DashboardController extends Controller
             'pendingTickets' => $pendingTickets,
             'washerDebts' => $washerDebts,
             'pettyCashAmount' => $pettyCashAmount,
+            'lowStockCount' => $lowStockCount,
         ]);
     }
 

--- a/app/Http/Controllers/InventoryMovementController.php
+++ b/app/Http/Controllers/InventoryMovementController.php
@@ -47,6 +47,7 @@ class InventoryMovementController extends Controller
         return view('inventory.index', [
             'movements' => $movements,
             'filters' => $request->only(['start', 'end', 'product']),
+            'lowStockProducts' => Product::lowStockItems(),
         ]);
     }
 

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\AppSetting;
 use App\Models\Product;
 use App\Models\InventoryMovement;
 use Illuminate\Http\Request;
@@ -39,7 +40,9 @@ class ProductController extends Controller
 
     public function create()
     {
-        return view('products.create');
+        return view('products.create', [
+            'defaultMinimumStock' => AppSetting::defaultMinimumStock(),
+        ]);
     }
 
     public function store(Request $request)
@@ -76,7 +79,10 @@ class ProductController extends Controller
 
     public function edit(Product $product)
     {
-        return view('products.edit', compact('product'));
+        return view('products.edit', [
+            'product' => $product,
+            'defaultMinimumStock' => AppSetting::defaultMinimumStock(),
+        ]);
     }
 
     public function update(Request $request, Product $product)

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -33,6 +33,7 @@ class ProductController extends Controller
         return view('products.index', [
             'products' => $products,
             'filters' => $request->only('q'),
+            'lowStockProducts' => Product::lowStockItems(),
         ]);
     }
 
@@ -46,10 +47,18 @@ class ProductController extends Controller
         $request->validate([
             'name' => 'required|string|max:255|unique:products,name',
             'price' => 'required|numeric|min:0',
-            'stock' => 'required|integer|min:0'
+            'stock' => 'required|integer|min:0',
+            'low_stock_threshold' => 'nullable|integer|min:0',
         ]);
 
-        $product = Product::create($request->only('name', 'price', 'stock'));
+        $product = Product::create([
+            'name' => $request->name,
+            'price' => $request->price,
+            'stock' => $request->stock,
+            'low_stock_threshold' => $request->filled('low_stock_threshold')
+                ? (int) $request->low_stock_threshold
+                : null,
+        ]);
 
         if ($product->stock > 0) {
             InventoryMovement::create([
@@ -74,10 +83,17 @@ class ProductController extends Controller
     {
         $request->validate([
             'name' => 'required|string|max:255|unique:products,name,' . $product->id,
-            'price' => 'required|numeric|min:0'
+            'price' => 'required|numeric|min:0',
+            'low_stock_threshold' => 'nullable|integer|min:0',
         ]);
 
-        $product->update($request->only('name', 'price'));
+        $product->update([
+            'name' => $request->name,
+            'price' => $request->price,
+            'low_stock_threshold' => $request->filled('low_stock_threshold')
+                ? (int) $request->low_stock_threshold
+                : null,
+        ]);
 
         return redirect()->route('products.index')
             ->with('success', 'Producto actualizado correctamente.');

--- a/app/Http/Middleware/BlockMobileDevices.php
+++ b/app/Http/Middleware/BlockMobileDevices.php
@@ -9,6 +9,10 @@ class BlockMobileDevices
 {
     public function handle(Request $request, Closure $next)
     {
+        if (! \App\Models\AppSetting::blockMobileDevicesEnabled()) {
+            return $next($request);
+        }
+
         if ($this->isMobile($request)) {
             return response()->view('mobile-warning');
         }

--- a/app/Models/AppSetting.php
+++ b/app/Models/AppSetting.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Schema;
+
+class AppSetting extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['block_mobile_devices'];
+
+    protected $casts = [
+        'block_mobile_devices' => 'boolean',
+    ];
+
+    public static function blockMobileDevicesEnabled(): bool
+    {
+        if (! Schema::hasTable('app_settings')) {
+            return true;
+        }
+
+        return Cache::remember('app_settings.block_mobile', 300, function () {
+            return optional(static::query()->first())->block_mobile_devices ?? true;
+        });
+    }
+
+    public static function updateBlockMobileDevices(bool $enabled): void
+    {
+        $settings = static::query()->first();
+
+        if ($settings) {
+            $settings->update(['block_mobile_devices' => $enabled]);
+        } else {
+            static::query()->create(['block_mobile_devices' => $enabled]);
+        }
+
+        Cache::forget('app_settings');
+        Cache::forget('app_settings.block_mobile');
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -9,7 +9,24 @@ class Product extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['name', 'price', 'stock'];
+    protected $fillable = ['name', 'price', 'stock', 'low_stock_threshold'];
+
+    protected $casts = [
+        'stock' => 'integer',
+        'low_stock_threshold' => 'integer',
+    ];
+
+    public function scopeLowStock($query)
+    {
+        return $query->whereNotNull('low_stock_threshold')
+            ->where('low_stock_threshold', '>', 0)
+            ->whereColumn('stock', '<=', 'low_stock_threshold');
+    }
+
+    public static function lowStockItems()
+    {
+        return static::lowStock()->orderBy('name')->get();
+    }
 
     public function inventoryMovements()
     {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Models\AppearanceSetting;
+use App\Models\AppSetting;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\View;
@@ -33,6 +34,16 @@ class AppServiceProvider extends ServiceProvider
             });
 
             $view->with('appearanceSettings', $settings);
+
+            $appSettings = Cache::remember('app_settings', 300, function () {
+                if (! Schema::hasTable('app_settings')) {
+                    return null;
+                }
+
+                return AppSetting::first();
+            });
+
+            $view->with('appSettings', $appSettings);
         });
     }
 }

--- a/database/migrations/2025_10_10_000001_add_low_stock_threshold_to_products_table.php
+++ b/database/migrations/2025_10_10_000001_add_low_stock_threshold_to_products_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->unsignedInteger('low_stock_threshold')->nullable()->after('stock');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('low_stock_threshold');
+        });
+    }
+};

--- a/database/migrations/2025_10_10_000002_create_app_settings_table.php
+++ b/database/migrations/2025_10_10_000002_create_app_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('app_settings', function (Blueprint $table) {
+            $table->id();
+            $table->boolean('block_mobile_devices')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('app_settings');
+    }
+};

--- a/database/migrations/2025_10_10_000003_add_default_minimum_stock_to_app_settings_table.php
+++ b/database/migrations/2025_10_10_000003_add_default_minimum_stock_to_app_settings_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasTable('app_settings')) {
+            return;
+        }
+
+        Schema::table('app_settings', function (Blueprint $table) {
+            if (! Schema::hasColumn('app_settings', 'default_minimum_stock')) {
+                $table->unsignedInteger('default_minimum_stock')->default(5)->after('block_mobile_devices');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (! Schema::hasTable('app_settings')) {
+            return;
+        }
+
+        Schema::table('app_settings', function (Blueprint $table) {
+            if (Schema::hasColumn('app_settings', 'default_minimum_stock')) {
+                $table->dropColumn('default_minimum_stock');
+            }
+        });
+    }
+};

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -39,6 +39,7 @@
                 'pettyCashTotal' => $pettyCashTotal,
                 'accountsReceivable' => $accountsReceivable,
                 'pendingTickets' => $pendingTickets,
+                'lowStockCount' => $lowStockCount,
             ])
         </div>
     </div>

--- a/resources/views/dashboard/partials/summary.blade.php
+++ b/resources/views/dashboard/partials/summary.blade.php
@@ -1,4 +1,13 @@
 <div class="space-y-4">
+    @if($lowStockCount > 0)
+        <div class="p-4 border border-yellow-300 bg-yellow-50 text-yellow-800 rounded flex flex-wrap items-center justify-between gap-3">
+            <div>
+                <p class="font-semibold">Inventario con stock bajo</p>
+                <p class="text-sm">Hay {{ $lowStockCount }} {{ \Illuminate\Support\Str::plural('producto', $lowStockCount) }} en o por debajo del mínimo configurado.</p>
+            </div>
+            <a href="{{ route('inventory.index') }}" class="px-4 py-2 bg-yellow-600 text-white rounded hover:bg-yellow-700">Revisar inventario</a>
+        </div>
+    @endif
     <div class="bg-white p-4 shadow sm:rounded-lg flex justify-around items-center">
         <div class="text-center">
             <p class="text-lg">Total en caja</p>

--- a/resources/views/inventory/index.blade.php
+++ b/resources/views/inventory/index.blade.php
@@ -7,6 +7,10 @@
 
     <div x-data="filterTable('{{ route('inventory.index') }}')" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
 
+        @isset($lowStockProducts)
+            @include('partials.low-stock-panel', ['products' => $lowStockProducts])
+        @endisset
+
         <div class="mb-4 flex flex-wrap items-end gap-4">
             <form method="GET" x-ref="form" class="flex items-end gap-2">
                 <div>

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -70,14 +70,21 @@
                 </div>
             </div>
             @if(auth()->user()->role === 'admin')
-            <div x-data="{ open: {{ request()->routeIs('discounts.*','users.*','bank-accounts.*') ? 'true' : 'false' }} }">
-                <button type="button" @click="open=!open" class="w-full text-left px-3 py-2 font-semibold rounded hover:bg-gray-100 {{ request()->routeIs('discounts.*','users.*','bank-accounts.*') ? 'bg-gray-200' : '' }}">
+            <div x-data="{ open: {{ request()->routeIs('settings.*','discounts.*','users.*','bank-accounts.*','appearance.*') ? 'true' : 'false' }} }">
+                <button type="button" @click="open=!open" class="w-full text-left px-3 py-2 font-semibold rounded hover:bg-gray-100 {{ request()->routeIs('settings.*','discounts.*','users.*','bank-accounts.*','appearance.*') ? 'bg-gray-200' : '' }}">
                     <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12a7.5 7.5 0 0 1 15 0 7.5 7.5 0 0 1-15 0z" />
                     </svg>
                     Configuración
                 </button>
                 <div x-show="open" x-cloak class="pl-6 space-y-1">
+                    <a href="{{ route('settings.edit') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('settings.*') ? 'border-b-2 border-gray-500' : '' }}">
+                        <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93l.893.36c.512.207.775.783.614 1.31l-.285.93a1.125 1.125 0 0 0 .284 1.115l.642.642c.39.39.44 1.002.118 1.45l-.6.825a1.125 1.125 0 0 1-1.28.45l-.893-.36a1.125 1.125 0 0 0-1.066.21l-.813.659c-.428.347-1.04.347-1.468 0l-.813-.659a1.125 1.125 0 0 0-1.066-.21l-.893.36a1.125 1.125 0 0 1-1.28-.45l-.6-.825a1.125 1.125 0 0 1 .118-1.45l.642-.642a1.125 1.125 0 0 0 .284-1.115l-.285-.93c-.161-.527.102-1.103.614-1.31l.893-.36a1.125 1.125 0 0 0 .78-.93l.149-.894z" />
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" />
+                        </svg>
+                        Ajustes
+                    </a>
                     <a href="{{ route('discounts.index') }}" class="block px-3 py-2 rounded hover:bg-gray-100 {{ request()->routeIs('discounts.*') ? 'border-b-2 border-gray-500' : '' }}">
                         <svg class="inline-block w-4 h-4 mr-1 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75v10.5M6.75 6.75v10.5m-1.5-9h14.5m-14.5 4.5h14.5" />
@@ -102,24 +109,6 @@
                         </svg>
                         Usuarios
                     </a>
-                    <div class="mt-4 pt-4 border-t border-gray-200">
-                        <form method="POST" action="{{ route('settings.mobile-access.update') }}" x-data="{ enabled: {{ json_encode(optional($appSettings)->block_mobile_devices ?? true) }} }" class="space-y-1">
-                            @csrf
-                            @method('PUT')
-                            <input type="hidden" name="block_mobile_devices" :value="enabled ? 1 : 0">
-                            <div class="flex items-center justify-between">
-                                <div>
-                                    <p class="text-sm font-medium text-gray-700">Bloquear acceso móvil</p>
-                                    <p class="text-xs text-gray-500">Controla si la plataforma restringe dispositivos móviles.</p>
-                                </div>
-                                <label class="relative inline-flex items-center cursor-pointer">
-                                    <input type="checkbox" class="sr-only peer" x-model="enabled" @change="$nextTick(() => $event.target.form.submit())">
-                                    <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-300 rounded-full peer peer-checked:bg-blue-600 transition-all relative after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border after:border-gray-300 after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-5 peer-checked:after:border-white"></div>
-                                    <span class="ml-2 text-xs text-gray-600" x-text="enabled ? 'Activo' : 'Inactivo'"></span>
-                                </label>
-                            </div>
-                        </form>
-                    </div>
                 </div>
             </div>
             @endif

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -102,6 +102,24 @@
                         </svg>
                         Usuarios
                     </a>
+                    <div class="mt-4 pt-4 border-t border-gray-200">
+                        <form method="POST" action="{{ route('settings.mobile-access.update') }}" x-data="{ enabled: {{ json_encode(optional($appSettings)->block_mobile_devices ?? true) }} }" class="space-y-1">
+                            @csrf
+                            @method('PUT')
+                            <input type="hidden" name="block_mobile_devices" :value="enabled ? 1 : 0">
+                            <div class="flex items-center justify-between">
+                                <div>
+                                    <p class="text-sm font-medium text-gray-700">Bloquear acceso móvil</p>
+                                    <p class="text-xs text-gray-500">Controla si la plataforma restringe dispositivos móviles.</p>
+                                </div>
+                                <label class="relative inline-flex items-center cursor-pointer">
+                                    <input type="checkbox" class="sr-only peer" x-model="enabled" @change="$nextTick(() => $event.target.form.submit())">
+                                    <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-300 rounded-full peer peer-checked:bg-blue-600 transition-all relative after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border after:border-gray-300 after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-5 peer-checked:after:border-white"></div>
+                                    <span class="ml-2 text-xs text-gray-600" x-text="enabled ? 'Activo' : 'Inactivo'"></span>
+                                </label>
+                            </div>
+                        </form>
+                    </div>
                 </div>
             </div>
             @endif

--- a/resources/views/partials/low-stock-panel.blade.php
+++ b/resources/views/partials/low-stock-panel.blade.php
@@ -11,7 +11,17 @@
             <div class="flex items-center justify-between bg-white border border-yellow-200 rounded p-3">
                 <div>
                     <p class="font-semibold text-gray-800">{{ $product->name }}</p>
-                    <p class="text-xs text-gray-600">Stock actual: {{ $product->stock }} | Mínimo: {{ $product->low_stock_threshold }}</p>
+                    <p class="text-xs text-gray-600">
+                        Stock actual: {{ $product->stock }} |
+                        Mínimo:
+                        @if($product->low_stock_threshold)
+                            {{ $product->low_stock_threshold }}
+                        @elseif($product->effective_low_stock_threshold)
+                            Predeterminado ({{ $product->effective_low_stock_threshold }})
+                        @else
+                            —
+                        @endif
+                    </p>
                 </div>
                 <a href="{{ route('inventory.create', ['product_id' => $product->id]) }}" class="px-3 py-2 text-sm bg-yellow-600 text-white rounded hover:bg-yellow-700">Registrar entrada</a>
             </div>

--- a/resources/views/partials/low-stock-panel.blade.php
+++ b/resources/views/partials/low-stock-panel.blade.php
@@ -1,0 +1,21 @@
+@if($products->isNotEmpty())
+<div class="mb-6 border border-yellow-300 bg-yellow-50 text-yellow-800 rounded p-4 space-y-3">
+    <div class="flex flex-wrap items-center justify-between gap-3">
+        <div>
+            <h3 class="text-lg font-semibold">Productos con stock bajo</h3>
+            <p class="text-sm text-yellow-700">Estos productos están en o por debajo del mínimo configurado.</p>
+        </div>
+    </div>
+    <div class="grid gap-3 md:grid-cols-2">
+        @foreach($products as $product)
+            <div class="flex items-center justify-between bg-white border border-yellow-200 rounded p-3">
+                <div>
+                    <p class="font-semibold text-gray-800">{{ $product->name }}</p>
+                    <p class="text-xs text-gray-600">Stock actual: {{ $product->stock }} | Mínimo: {{ $product->low_stock_threshold }}</p>
+                </div>
+                <a href="{{ route('inventory.create', ['product_id' => $product->id]) }}" class="px-3 py-2 text-sm bg-yellow-600 text-white rounded hover:bg-yellow-700">Registrar entrada</a>
+            </div>
+        @endforeach
+    </div>
+</div>
+@endif

--- a/resources/views/products/create.blade.php
+++ b/resources/views/products/create.blade.php
@@ -25,6 +25,12 @@
                 <input type="number" name="stock" required class="form-input w-full">
             </div>
 
+            <div>
+                <label for="low_stock_threshold" class="block font-medium text-sm text-gray-700">Aviso de escasez</label>
+                <input type="number" name="low_stock_threshold" min="0" value="{{ old('low_stock_threshold') }}" class="form-input w-full" placeholder="Opcional">
+                <p class="mt-1 text-xs text-gray-500">El sistema avisará cuando el stock llegue a este mínimo.</p>
+            </div>
+
             <div class="flex items-center gap-4">
                 <x-primary-button>Guardar</x-primary-button>
                 <x-secondary-button type="button" onclick="window.location='{{ route('products.index') }}'">Cancelar</x-secondary-button>

--- a/resources/views/products/create.blade.php
+++ b/resources/views/products/create.blade.php
@@ -28,7 +28,10 @@
             <div>
                 <label for="low_stock_threshold" class="block font-medium text-sm text-gray-700">Aviso de escasez</label>
                 <input type="number" name="low_stock_threshold" min="0" value="{{ old('low_stock_threshold') }}" class="form-input w-full" placeholder="Opcional">
-                <p class="mt-1 text-xs text-gray-500">El sistema avisará cuando el stock llegue a este mínimo.</p>
+                <p class="mt-1 text-xs text-gray-500">
+                    El sistema avisará cuando el stock llegue a este mínimo.
+                    Si lo dejas vacío usaremos el valor general de {{ $defaultMinimumStock }} unidades.
+                </p>
             </div>
 
             <div class="flex items-center gap-4">

--- a/resources/views/products/edit.blade.php
+++ b/resources/views/products/edit.blade.php
@@ -25,6 +25,12 @@
                 <input type="number" value="{{ $product->stock }}" disabled class="form-input w-full bg-gray-100">
             </div>
 
+            <div>
+                <label for="low_stock_threshold" class="block font-medium text-sm text-gray-700">Aviso de escasez</label>
+                <input type="number" name="low_stock_threshold" min="0" value="{{ old('low_stock_threshold', $product->low_stock_threshold) }}" class="form-input w-full" placeholder="Opcional">
+                <p class="mt-1 text-xs text-gray-500">Establece el stock mínimo antes de mostrar alertas.</p>
+            </div>
+
             <div class="flex items-center gap-4">
                 <button class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
                     Actualizar

--- a/resources/views/products/edit.blade.php
+++ b/resources/views/products/edit.blade.php
@@ -28,7 +28,10 @@
             <div>
                 <label for="low_stock_threshold" class="block font-medium text-sm text-gray-700">Aviso de escasez</label>
                 <input type="number" name="low_stock_threshold" min="0" value="{{ old('low_stock_threshold', $product->low_stock_threshold) }}" class="form-input w-full" placeholder="Opcional">
-                <p class="mt-1 text-xs text-gray-500">Establece el stock mínimo antes de mostrar alertas.</p>
+                <p class="mt-1 text-xs text-gray-500">
+                    Establece el stock mínimo antes de mostrar alertas.
+                    Si lo dejas vacío usaremos el valor general de {{ $defaultMinimumStock }} unidades.
+                </p>
             </div>
 
             <div class="flex items-center gap-4">

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -8,6 +8,10 @@
     <div x-data="filterTable('{{ route('products.index') }}', {selected: null})" x-on:click.away="selected = null" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
 
 
+        @isset($lowStockProducts)
+            @include('partials.low-stock-panel', ['products' => $lowStockProducts])
+        @endisset
+
         @if (auth()->user()->role === 'admin')
             <div class="mb-4 flex items-center gap-4">
                 <a href="{{ route('products.create') }}" class="btn-primary">
@@ -45,6 +49,10 @@
                     <div>
                         <label class="block font-medium text-sm text-gray-700">Precio (RD$)</label>
                         <input type="number" step="0.01" name="price" value="{{ $product->price }}" required class="form-input w-full">
+                    </div>
+                    <div>
+                        <label class="block font-medium text-sm text-gray-700">Aviso de escasez</label>
+                        <input type="number" name="low_stock_threshold" min="0" value="{{ $product->low_stock_threshold }}" class="form-input w-full" placeholder="Opcional">
                     </div>
                     <div class="mt-6 flex justify-end">
                         <x-secondary-button x-on:click="$dispatch('close')">Cancelar</x-secondary-button>

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -5,6 +5,9 @@
         </h2>
     </x-slot>
 
+    @php
+        $defaultMinimumStock = optional($appSettings)->default_minimum_stock ?? \App\Models\AppSetting::DEFAULT_MINIMUM_STOCK;
+    @endphp
     <div x-data="filterTable('{{ route('products.index') }}', {selected: null})" x-on:click.away="selected = null" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
 
 
@@ -53,6 +56,7 @@
                     <div>
                         <label class="block font-medium text-sm text-gray-700">Aviso de escasez</label>
                         <input type="number" name="low_stock_threshold" min="0" value="{{ $product->low_stock_threshold }}" class="form-input w-full" placeholder="Opcional">
+                        <p class="mt-1 text-xs text-gray-500">Si lo dejas vacío usaremos el valor general de {{ $defaultMinimumStock }} unidades.</p>
                     </div>
                     <div class="mt-6 flex justify-end">
                         <x-secondary-button x-on:click="$dispatch('close')">Cancelar</x-secondary-button>

--- a/resources/views/products/partials/table.blade.php
+++ b/resources/views/products/partials/table.blade.php
@@ -14,12 +14,20 @@
                     x-on:click="selected = selected === {{ $product->id }} ? null : {{ $product->id }}"
                     :class="[
                         selected === {{ $product->id }} ? 'bg-blue-100' : '',
-                        {{ $product->low_stock_threshold && $product->low_stock_threshold > 0 && $product->stock <= $product->low_stock_threshold ? 1 : 0 }} ? 'bg-yellow-50' : ''
+                        {{ $product->effective_low_stock_threshold && $product->stock <= $product->effective_low_stock_threshold ? 1 : 0 }} ? 'bg-yellow-50' : ''
                     ]">
                     <td class="px-4 py-2">{{ $product->name }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($product->price, 2) }}</td>
                     <td class="px-4 py-2">{{ $product->stock }}</td>
-                    <td class="px-4 py-2">{{ $product->low_stock_threshold ?? '—' }}</td>
+                    <td class="px-4 py-2">
+                        @if($product->low_stock_threshold)
+                            {{ $product->low_stock_threshold }}
+                        @elseif($product->effective_low_stock_threshold)
+                            Predeterminado ({{ $product->effective_low_stock_threshold }})
+                        @else
+                            —
+                        @endif
+                    </td>
                 </tr>
             @endforeach
         </tbody>

--- a/resources/views/products/partials/table.blade.php
+++ b/resources/views/products/partials/table.blade.php
@@ -5,16 +5,21 @@
                 <th class="px-4 py-2 border">Nombre</th>
                 <th class="px-4 py-2 border">Precio</th>
                 <th class="px-4 py-2 border">Stock</th>
+                <th class="px-4 py-2 border">Aviso de escasez</th>
             </tr>
         </thead>
         <tbody>
             @foreach ($products as $product)
                 <tr class="border-t cursor-pointer"
                     x-on:click="selected = selected === {{ $product->id }} ? null : {{ $product->id }}"
-                    :class="selected === {{ $product->id }} ? 'bg-blue-100' : ''">
+                    :class="[
+                        selected === {{ $product->id }} ? 'bg-blue-100' : '',
+                        {{ $product->low_stock_threshold && $product->low_stock_threshold > 0 && $product->stock <= $product->low_stock_threshold ? 1 : 0 }} ? 'bg-yellow-50' : ''
+                    ]">
                     <td class="px-4 py-2">{{ $product->name }}</td>
                     <td class="px-4 py-2">RD$ {{ number_format($product->price, 2) }}</td>
                     <td class="px-4 py-2">{{ $product->stock }}</td>
+                    <td class="px-4 py-2">{{ $product->low_stock_threshold ?? '—' }}</td>
                 </tr>
             @endforeach
         </tbody>

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -1,0 +1,76 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Ajustes Generales') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-8">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white shadow sm:rounded-lg p-6 space-y-6">
+                @if (session('success'))
+                    <div class="rounded-md bg-green-50 p-4">
+                        <div class="flex">
+                            <div class="flex-shrink-0">
+                                <svg class="h-5 w-5 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.5 12.75l6 6 9-13.5" />
+                                </svg>
+                            </div>
+                            <div class="ml-3">
+                                <p class="text-sm text-green-700">{{ session('success') }}</p>
+                            </div>
+                        </div>
+                    </div>
+                @endif
+
+                <form method="POST" action="{{ route('settings.update') }}" class="space-y-6">
+                    @csrf
+                    @method('PUT')
+
+                    <div>
+                        <h3 class="text-lg font-medium text-gray-900">Acceso a la plataforma</h3>
+                        <p class="mt-1 text-sm text-gray-500">Define si el sistema debe bloquear el acceso cuando se detecta un dispositivo móvil.</p>
+
+                        <div class="mt-4 flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3">
+                            <div>
+                                <p class="text-sm font-semibold text-gray-800">Bloquear acceso desde móviles</p>
+                                <p class="text-xs text-gray-500">Cuando está activo, los teléfonos y tabletas verán una advertencia al intentar ingresar.</p>
+                            </div>
+                            <div class="flex items-center" x-data="{ enabled: {{ old('block_mobile_devices', $blockMobile) ? 'true' : 'false' }} }">
+                                <input type="hidden" name="block_mobile_devices" value="0">
+                                <label class="relative inline-flex items-center cursor-pointer">
+                                    <input type="checkbox" name="block_mobile_devices" value="1" class="sr-only peer" x-model="enabled" @checked(old('block_mobile_devices', $blockMobile))>
+                                    <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-300 rounded-full peer peer-checked:bg-blue-600 transition-all relative after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border after:border-gray-300 after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-5 peer-checked:after:border-white"></div>
+                                    <span class="ml-2 text-xs text-gray-600" x-text="enabled ? 'Activo' : 'Inactivo'">
+                                        {{ old('block_mobile_devices', $blockMobile) ? 'Activo' : 'Inactivo' }}
+                                    </span>
+                                </label>
+                            </div>
+                        </div>
+                        @error('block_mobile_devices')
+                            <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div>
+                        <h3 class="text-lg font-medium text-gray-900">Inventario</h3>
+                        <p class="mt-1 text-sm text-gray-500">Establece el mínimo de unidades que se considerarán como stock bajo cuando un producto no tenga su propio límite.</p>
+
+                        <div class="mt-4">
+                            <label for="default_minimum_stock" class="block text-sm font-medium text-gray-700">Stock mínimo predeterminado</label>
+                            <input type="number" name="default_minimum_stock" id="default_minimum_stock" min="0" class="mt-1 form-input w-full max-w-xs" value="{{ old('default_minimum_stock', $defaultMinimumStock) }}">
+                            <p class="mt-2 text-xs text-gray-500">Aplicaremos este valor a todos los productos sin un aviso de escasez individual configurado.</p>
+                            @error('default_minimum_stock')
+                                <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                            @enderror
+                        </div>
+                    </div>
+
+                    <div class="flex items-center gap-3">
+                        <x-primary-button>Guardar cambios</x-primary-button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/tickets/index.blade.php
+++ b/resources/views/tickets/index.blade.php
@@ -5,7 +5,7 @@
         </h2>
     </x-slot>
 
-    <div x-data="filterTable('{{ route('tickets.index') }}', {selected: null, selectedPending: false, selectedNoWasher: false, selectedCreated: null, pending: {{ $filters['pending'] ?? 'null' }}, role: '{{ Auth::user()->role }}', editBase: '{{ url('tickets') }}'})" x-on:click.away="selected = null; selectedPending=false; selectedNoWasher=false" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
+    <div x-data="filterTable('{{ route('tickets.index') }}', {selected: null, selectedPending: false, selectedNoWasher: false, selectedCreated: null, selectedPrint: null, pending: {{ $filters['pending'] ?? 'null' }}, role: '{{ Auth::user()->role }}', editBase: '{{ url('tickets') }}'})" x-on:click.away="selected = null; selectedPending=false; selectedNoWasher=false; selectedCreated=null; selectedPrint=null" class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
 
 
         <div class="mb-4 flex flex-wrap items-end gap-4">
@@ -40,6 +40,9 @@
             </button>
             <button x-show="selected && selectedPending" x-on:click="$dispatch('open-modal', 'pay-' + selected)" class="text-green-600" title="Pagar">
                 <i class="fa-solid fa-money-bill-wave fa-lg"></i>
+            </button>
+            <button type="button" x-show="selectedPrint" x-on:click="window.openTicketPrintTab(selectedPrint)" class="text-indigo-600" title="Reimprimir factura">
+                <i class="fa-solid fa-print fa-lg"></i>
             </button>
         </div>
 

--- a/resources/views/tickets/partials/table.blade.php
+++ b/resources/views/tickets/partials/table.blade.php
@@ -18,11 +18,12 @@
             @foreach ($tickets as $ticket)
                 @php $needsWasher = $ticket->washer_pending_amount > 0; @endphp
                 <tr class="border-t cursor-pointer {{ $ticket->pending ? 'bg-red-100' : ($needsWasher ? 'bg-orange-100' : '') }}"
+                    data-print-url="{{ $ticket->pending ? '' : route('tickets.print', $ticket) }}"
                     x-on:click="
                         if (selected === {{ $ticket->id }}) {
-                            selected = null; selectedPending = false; selectedNoWasher = false; selectedCreated = null;
+                            selected = null; selectedPending = false; selectedNoWasher = false; selectedCreated = null; selectedPrint = null;
                         } else {
-                            selected = {{ $ticket->id }}; selectedPending = {{ $ticket->pending ? 'true' : 'false' }}; selectedNoWasher = {{ $needsWasher ? 'true' : 'false' }}; selectedCreated = '{{ $ticket->created_at }}';
+                            selected = {{ $ticket->id }}; selectedPending = {{ $ticket->pending ? 'true' : 'false' }}; selectedNoWasher = {{ $needsWasher ? 'true' : 'false' }}; selectedCreated = '{{ $ticket->created_at }}'; selectedPrint = $el.dataset.printUrl || null;
                         }
                     "
                     :class="selected === {{ $ticket->id }} ? (selectedPending ? 'bg-red-300' : (selectedNoWasher ? 'bg-orange-300' : 'bg-blue-100')) : ''">

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\PettyCashExpenseController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\InventoryMovementController;
 use App\Http\Controllers\AppearanceController;
+use App\Http\Controllers\AppSettingController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -47,6 +48,8 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::resource('bank-accounts', \App\Http\Controllers\BankAccountController::class);
     Route::get('appearance', [AppearanceController::class, 'index'])->name('appearance.index');
     Route::post('appearance', [AppearanceController::class, 'store'])->name('appearance.store');
+    Route::put('settings/mobile-access', [AppSettingController::class, 'updateMobileAccess'])
+        ->name('settings.mobile-access.update');
     Route::post('petty-cash/fund', [PettyCashExpenseController::class, 'updateFund'])->name('petty-cash.update-fund');
 });
 Route::middleware(['auth', 'role:admin,cajero'])->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,8 +48,8 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::resource('bank-accounts', \App\Http\Controllers\BankAccountController::class);
     Route::get('appearance', [AppearanceController::class, 'index'])->name('appearance.index');
     Route::post('appearance', [AppearanceController::class, 'store'])->name('appearance.store');
-    Route::put('settings/mobile-access', [AppSettingController::class, 'updateMobileAccess'])
-        ->name('settings.mobile-access.update');
+    Route::get('settings', [AppSettingController::class, 'edit'])->name('settings.edit');
+    Route::put('settings', [AppSettingController::class, 'update'])->name('settings.update');
     Route::post('petty-cash/fund', [PettyCashExpenseController::class, 'updateFund'])->name('petty-cash.update-fund');
 });
 Route::middleware(['auth', 'role:admin,cajero'])->group(function () {

--- a/tests/Feature/MobileAccessTest.php
+++ b/tests/Feature/MobileAccessTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\AppSetting;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -23,6 +24,18 @@ class MobileAccessTest extends TestCase
     {
         $response = $this->withHeaders([
             'User-Agent' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36'
+        ])->get('/login');
+
+        $response->assertStatus(200);
+        $response->assertDontSee('Acceso temporalmente restringido');
+    }
+
+    public function test_mobile_device_can_access_when_restriction_disabled(): void
+    {
+        AppSetting::updateBlockMobileDevices(false);
+
+        $response = $this->withHeaders([
+            'User-Agent' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_6 like Mac OS X)'
         ])->get('/login');
 
         $response->assertStatus(200);


### PR DESCRIPTION
## Summary
- add a print button to the ticket list so paid invoices can be re-opened for printing
- capture each ticket's print URL when selecting rows to drive the new action

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d2b0c7aa1c832ab07d6f090891473c